### PR TITLE
Updated 2_lab2: Replaced SendGrid with SparkPost for email sending

### DIFF
--- a/2_openai/2_lab2.ipynb
+++ b/2_openai/2_lab2.ipynb
@@ -23,9 +23,7 @@
     "## Before we start - some setup:\n",
     "\n",
     "\n",
-    "Please visit Sendgrid at: https://sendgrid.com/\n",
-    "\n",
-    "(Sendgrid is a Twilio company for sending emails.)\n",
+    "Please visit Sendgrid at: https://sendgrid.com/ (Sendgrid is a Twilio company for sending emails.)\n",
     "\n",
     "Please set up an account - it's free! (at least, for me, right now).\n",
     "\n",
@@ -40,12 +38,22 @@
     "And also, within SendGrid, go to:\n",
     "\n",
     "Settings (left sidebar) >> Sender Authentication >> \"Verify a Single Sender\"  \n",
-    "and verify that your own email address is a real email address, so that SendGrid can send emails for you.\n"
+    "and verify that your own email address is a real email address, so that SendGrid can send emails for you.\n",
+    "\n",
+    "NEW: May 7, 2025\n",
+    "Unfortunately, SendGrid is having issues as of the moment. An alternative is: https://app.sparkpost.com/\n",
+    "Create the key (https://app.sparkpost.com/account/api-keys) and copy it to the clipboard, then add a new line to your .env file:\n",
+    "`SPARKPOST_API_KEY=xxxx`\n",
+    "\n",
+    "To install your library, under zsh terminal:\n",
+    "`uv pip install sparkpost`\n",
+    "\n",
+    "Make sure to `verify your email` first!\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,14 +65,26 @@
     "import os\n",
     "from sendgrid.helpers.mail import Mail, Email, To, Content\n",
     "import asyncio\n",
-    "\n"
+    "\n",
+    "from sparkpost import SparkPost"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "load_dotenv(override=True)"
    ]
@@ -78,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,9 +142,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subject: Simplify Your SOC 2 Compliance with ComplAI\n",
+      "\n",
+      "Dear [Recipient's Name],\n",
+      "\n",
+      "I hope this message finds you well.\n",
+      "\n",
+      "In today’s fast-paced digital landscape, achieving and maintaining SOC 2 compliance can be a daunting task. At ComplAI, we understand the complexities and nuances involved. Our AI-powered SaaS tool streamlines the compliance process, enabling organizations like yours to navigate audits with confidence and ease.\n",
+      "\n",
+      "With ComplAI, you will benefit from:\n",
+      "\n",
+      "- **Automated Documentation**: Reduce the manual effort of maintaining compliance records.\n",
+      "- **Real-Time Monitoring**: Stay ahead with alerts and insights that highlight potential gaps.\n",
+      "- **Tailored Solutions**: Customized compliance strategies that align with your business model.\n",
+      "\n",
+      "Companies using ComplAI have successfully reduced their audit preparation time by up to 50%, freeing up valuable resources to focus on what truly matters—growing your business.\n",
+      "\n",
+      "I would love the opportunity to discuss how ComplAI can support your compliance efforts. Are you available for a brief conversation this week?\n",
+      "\n",
+      "Thank you for considering ComplAI as your compliance partner.\n",
+      "\n",
+      "Best regards,\n",
+      "\n",
+      "[Your Name]  \n",
+      "[Your Position]  \n",
+      "ComplAI  \n",
+      "[Your Phone Number]  \n",
+      "[Your Email Address]  \n",
+      "[Your Company Website]  "
+     ]
+    }
+   ],
    "source": [
     "\n",
     "result = Runner.run_streamed(sales_agent1, input=\"Write a cold sales email\")\n",
@@ -135,9 +190,98 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subject: Simplify Your SOC 2 Compliance with ComplAI\n",
+      "\n",
+      "Hi [Recipient's Name],\n",
+      "\n",
+      "I hope this message finds you well. My name is [Your Name], and I’m reaching out to introduce you to ComplAI, a cutting-edge SaaS tool designed to streamline SOC 2 compliance and audit preparation using advanced AI technology.\n",
+      "\n",
+      "Navigating the complexities of compliance can be challenging and time-consuming. ComplAI simplifies this process by providing real-time insights, automated documentation, and tailored compliance workflows, allowing you to focus on what you do best—growing your business.\n",
+      "\n",
+      "Key benefits of ComplAI include:\n",
+      "\n",
+      "- **Efficient Audit Preparation:** Reduce the time spent on audits with automated tracking and reporting.\n",
+      "- **Centralized Documentation:** Maintain all necessary compliance documents in one intuitive platform.\n",
+      "- **Continuous Compliance Monitoring:** Ensure you stay compliant year-round, not just at audit time.\n",
+      "\n",
+      "I would love the opportunity to discuss how ComplAI can specifically address your organization’s needs. Are you available for a brief call this week?\n",
+      "\n",
+      "Thank you for considering ComplAI. I look forward to the possibility of working together.\n",
+      "\n",
+      "Best regards,\n",
+      "\n",
+      "[Your Name]  \n",
+      "[Your Position]  \n",
+      "ComplAI  \n",
+      "[Your Phone Number]  \n",
+      "[Your Email Address]  \n",
+      "[Website URL]  \n",
+      "\n",
+      "\n",
+      "Subject: Let’s Make SOC2 Compliance Less Painful Than a Monday Morning ☕️\n",
+      "\n",
+      "Hi [First Name],\n",
+      "\n",
+      "Let's cut to the chase: SOC2 compliance can often feel like trying to solve a Rubik's Cube blindfolded (with one hand tied behind your back). We get it. \n",
+      "\n",
+      "That’s where ComplAI swoops in like a superhero wearing a cape made of checklists and streamlined processes! 🦸‍♂️ Our magic formula? An AI-powered SaaS tool that turns your compliance woes into a smooth, easy-breezy audit preparation experience. \n",
+      "\n",
+      "Imagine sauntering into your next audit looking cool, calm, and collected—like you just walked off a beach instead of from an endless paper trail. With ComplAI, you can:\n",
+      "\n",
+      "- Wave goodbye to the late-night compliance panic attacks.\n",
+      "- Navigate the audit process like a seasoned pro (or at least like someone who’s done it once).\n",
+      "- Keep your team energy levels high with organized and straightforward compliance tasks.\n",
+      "\n",
+      "Let’s chat about how we can transform compliance from an Achilles heel into your company’s secret weapon. I promise it won’t be as tedious as reading the fine print on a user agreement!\n",
+      "\n",
+      "How does your calendar look this week for a quick chat? I promise to keep the compliance puns to a minimum (or not, if that’s your jam).\n",
+      "\n",
+      "Looking forward to hearing from you!\n",
+      "\n",
+      "Best,  \n",
+      "[Your Name]  \n",
+      "[Your Title]  \n",
+      "ComplAI  \n",
+      "[Your Phone Number]  \n",
+      "[Your LinkedIn/Website]  \n",
+      "\n",
+      "P.S. If compliance were a coffee, we’d definitely be the double shot espresso—strong and to the point! ☕️\n",
+      "\n",
+      "\n",
+      "Subject: Simplify Your SOC 2 Compliance Process\n",
+      "\n",
+      "Hi [Recipient's Name],\n",
+      "\n",
+      "I hope this message finds you well. I'm reaching out to introduce ComplAI, a cutting-edge SaaS tool designed to streamline your SOC 2 compliance and audit preparation.\n",
+      "\n",
+      "With our AI-powered platform, you can:\n",
+      "\n",
+      "- Automate compliance tasks\n",
+      "- Reduce audit preparation time by up to 50%\n",
+      "- Enhance your security posture\n",
+      "\n",
+      "Would you be open to a quick call next week to explore how ComplAI can simplify your compliance journey?\n",
+      "\n",
+      "Looking forward to connecting!\n",
+      "\n",
+      "Best,  \n",
+      "[Your Name]  \n",
+      "[Your Position]  \n",
+      "ComplAI  \n",
+      "[Your Phone Number]  \n",
+      "[Your Email Address]  \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "message = \"Write a cold sales email\"\n",
     "\n",
@@ -156,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,9 +315,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best sales email:\n",
+      "Subject: Let’s Get Compliant Faster Than Your Morning Coffee ☕️\n",
+      "\n",
+      "Hey [Recipient's Name],\n",
+      "\n",
+      "I hope this email finds you well and possibly sipping on that lifeblood we call coffee!\n",
+      "\n",
+      "You know how it feels when your inbox is flooded, your to-do list is longer than a TikTok scroll, and then someone drops the “SOC 2 audit” bomb? 😱\n",
+      "\n",
+      "At ComplAI, we get it. We’ve made it our mission to transform SOC 2 compliance from a stressful, hair-pulling ordeal into a smooth, AI-powered process that even your cat could navigate. (Just kidding, but you get the idea!)\n",
+      "\n",
+      "Imagine:\n",
+      "\n",
+      "📝 Automagically generating compliance reports \n",
+      "🔍 Spotting potential issues before the auditors do (sneaky, huh?) \n",
+      "⏳ Saving you time to focus on what really matters – like perfecting your legendary coffee brew!\n",
+      "\n",
+      "If you’re curious about how we can turn those compliance nightmares into sweet dreams, I’d love to chat. I promise to keep it pun-ny and delightful!\n",
+      "\n",
+      "Ready to make audits feel like a walk in the park? 🌳\n",
+      "\n",
+      "Best brews,  \n",
+      "[Your Name]  \n",
+      "[Your Job Title]  \n",
+      "ComplAI  \n",
+      "[Your Phone Number]  \n",
+      "[Your LinkedIn Profile]  \n",
+      "\n",
+      "P.S. No cats were harmed in the making of this email. But we’re happy to take all the credit for whatever caffeinated genius you unleash!\n"
+     ]
+    }
+   ],
    "source": [
     "message = \"Write a cold sales email\"\n",
     "\n",
@@ -214,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,9 +419,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Agent(name='Professional Sales Agent', instructions='You are a sales agent working for ComplAI, a company that provides a SaaS tool for ensuring SOC2 compliance and preparing for audits, powered by AI. You write professional, serious cold emails.', handoff_description=None, handoffs=[], model='gpt-4o-mini', model_settings=ModelSettings(temperature=None, top_p=None, frequency_penalty=None, presence_penalty=None, tool_choice=None, parallel_tool_calls=None, truncation=None, max_tokens=None, reasoning=None, metadata=None, store=None), tools=[], mcp_servers=[], mcp_config={}, input_guardrails=[], output_guardrails=[], output_type=None, hooks=None, tool_use_behavior='run_llm_again', reset_tool_choice=True)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sales_agent1"
    ]
@@ -259,20 +450,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
+    "sp = SparkPost(os.environ[\"SPARKPOST_API_KEY\"])\n",
+    "\n",
     "@function_tool\n",
     "def send_email(body: str):\n",
-    "    \"\"\" Send out an email with the given body to all sales prospects \"\"\"\n",
-    "    sg = sendgrid.SendGridAPIClient(api_key=os.environ.get('SENDGRID_API_KEY'))\n",
-    "    from_email = Email(\"ed@edwarddonner.com\")  # Change to your verified sender\n",
-    "    to_email = To(\"ed.donner@gmail.com\")  # Change to your recipient\n",
-    "    content = Content(\"text/plain\", body)\n",
-    "    mail = Mail(from_email, to_email, \"Sales email\", content).get()\n",
-    "    response = sg.client.mail.send.post(request_body=mail)\n",
-    "    return {\"status\": \"success\"}"
+    "    \"\"\"Send out an email with the given body to all sales prospects using SparkPost\"\"\"\n",
+    "    response = sp.transmissions.send(\n",
+    "        recipients=[\"josejaimefelixgarcia@gmail.com\"],      # 🔁 Replace with actual recipient(s)\n",
+    "        text=body,\n",
+    "        from_email=\"test@sparkpostbox.com\",        # ✅ sandbox sender\n",
+    "        subject=\"Sales email\",\n",
+    "        options={\"sandbox\": True}\n",
+    "    )\n",
+    "    return {\"status\": \"success\", \"response\": response}"
    ]
   },
   {
@@ -284,9 +478,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "FunctionTool(name='send_email', description='Send out an email with the given body to all sales prospects using SparkPost', params_json_schema={'properties': {'body': {'title': 'Body', 'type': 'string'}}, 'required': ['body'], 'title': 'send_email_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f4cc400>, strict_json_schema=True)"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Let's look at it\n",
     "send_email"
@@ -301,9 +506,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "FunctionTool(name='sales_agent1', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent1_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f444cc0>, strict_json_schema=True)"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tool1 = sales_agent1.as_tool(tool_name=\"sales_agent1\", tool_description=\"Write a cold sales email\")\n",
     "tool1"
@@ -322,9 +538,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[FunctionTool(name='sales_agent1', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent1_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f444860>, strict_json_schema=True),\n",
+       " FunctionTool(name='sales_agent2', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent2_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x107753380>, strict_json_schema=True),\n",
+       " FunctionTool(name='sales_agent3', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent3_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f446ac0>, strict_json_schema=True),\n",
+       " FunctionTool(name='send_email', description='Send out an email with the given body to all sales prospects using SparkPost', params_json_schema={'properties': {'body': {'title': 'Body', 'type': 'string'}}, 'required': ['body'], 'title': 'send_email_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f4cc400>, strict_json_schema=True)]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "description = \"Write a cold sales email\"\n",
     "\n",
@@ -346,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,25 +665,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
+    "sp = SparkPost(os.environ[\"SPARKPOST_API_KEY\"])\n",
+    "\n",
     "@function_tool\n",
     "def send_html_email(subject: str, html_body: str) -> Dict[str, str]:\n",
-    "    \"\"\" Send out an email with the given subject and HTML body to all sales prospects \"\"\"\n",
-    "    sg = sendgrid.SendGridAPIClient(api_key=os.environ.get('SENDGRID_API_KEY'))\n",
-    "    from_email = Email(\"ed@edwarddonner.com\")  # Change to your verified sender\n",
-    "    to_email = To(\"ed.donner@gmail.com\")  # Change to your recipient\n",
-    "    content = Content(\"text/html\", html_body)\n",
-    "    mail = Mail(from_email, to_email, subject, content).get()\n",
-    "    response = sg.client.mail.send.post(request_body=mail)\n",
-    "    return {\"status\": \"success\"}"
+    "    \"\"\"Send out an email with the given subject and HTML body to all sales prospects using SparkPost\"\"\"\n",
+    "    response = sp.transmissions.send(\n",
+    "        recipients=[\"josejaimefelixgarcia@gmail.com\"],            # Replace with your recipient(s)\n",
+    "        html=html_body,\n",
+    "        from_email=\"test@sparkpostbox.com\",         # Must be a verified sender in SparkPost\n",
+    "        subject=subject\n",
+    "    )\n",
+    "    return {\"status\": \"success\", \"response\": response}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,16 +695,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[FunctionTool(name='subject_writer', description='Write a subject for a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'subject_writer_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f446c00>, strict_json_schema=True),\n",
+       " FunctionTool(name='html_converter', description='Convert a text email body to an HTML email body', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'html_converter_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f471d00>, strict_json_schema=True),\n",
+       " FunctionTool(name='send_html_email', description='Send out an email with the given subject and HTML body to all sales prospects using SparkPost', params_json_schema={'properties': {'subject': {'title': 'Subject', 'type': 'string'}, 'html_body': {'title': 'Html Body', 'type': 'string'}}, 'required': ['subject', 'html_body'], 'title': 'send_html_email_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f4cf100>, strict_json_schema=True)]"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tools"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,9 +743,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[FunctionTool(name='sales_agent1', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent1_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f444860>, strict_json_schema=True), FunctionTool(name='sales_agent2', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent2_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x107753380>, strict_json_schema=True), FunctionTool(name='sales_agent3', description='Write a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'sales_agent3_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f446ac0>, strict_json_schema=True)]\n",
+      "[Agent(name='Email Manager', instructions='You are an email formatter and sender. You receive the body of an email to be sent. You first use the subject_writer tool to write a subject for the email, then use the html_converter tool to convert the body to HTML. Finally, you use the send_html_email tool to send the email with the subject and HTML body.', handoff_description='Convert an email to HTML and send it', handoffs=[], model='gpt-4o-mini', model_settings=ModelSettings(temperature=None, top_p=None, frequency_penalty=None, presence_penalty=None, tool_choice=None, parallel_tool_calls=None, truncation=None, max_tokens=None, reasoning=None, metadata=None, store=None), tools=[FunctionTool(name='subject_writer', description='Write a subject for a cold sales email', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'subject_writer_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f446c00>, strict_json_schema=True), FunctionTool(name='html_converter', description='Convert a text email body to an HTML email body', params_json_schema={'properties': {'input': {'title': 'Input', 'type': 'string'}}, 'required': ['input'], 'title': 'html_converter_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f471d00>, strict_json_schema=True), FunctionTool(name='send_html_email', description='Send out an email with the given subject and HTML body to all sales prospects using SparkPost', params_json_schema={'properties': {'subject': {'title': 'Subject', 'type': 'string'}, 'html_body': {'title': 'Html Body', 'type': 'string'}}, 'required': ['subject', 'html_body'], 'title': 'send_html_email_args', 'type': 'object', 'additionalProperties': False}, on_invoke_tool=<function function_tool.<locals>._create_function_tool.<locals>._on_invoke_tool at 0x10f4cf100>, strict_json_schema=True)], mcp_servers=[], mcp_config={}, input_guardrails=[], output_guardrails=[], output_type=None, hooks=None, tool_use_behavior='run_llm_again', reset_tool_choice=True)]\n"
+     ]
+    }
+   ],
    "source": [
     "tools = [tool1, tool2, tool3]\n",
     "handoffs = [emailer_agent]\n",
@@ -509,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the email-sending functionality in 2_lab2.ipynb by switching from SendGrid to SparkPost.
	•	Replaced sendgrid SDK with sparkpost Python library
	•	Updated function send_email to use SparkPost API
	•	Note: SparkPost requires verified domains — free email addresses (e.g., Gmail) won’t work for sending unless configured

Let me know if you’d like to keep both options available or need help verifying a sending domain.