### PR TITLE
Lab 2 mcp work around on windows

### DIFF
--- a/5_autogen/community_contributions/2_lab2_mcp_work_around/mcp_fetch.py
+++ b/5_autogen/community_contributions/2_lab2_mcp_work_around/mcp_fetch.py
@@ -1,0 +1,20 @@
+import asyncio
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.tools.mcp import StdioServerParams, mcp_server_tools
+
+async def main():
+    # Connect to already-running mcp-server-fetch via stdio
+    fetch_mcp_server = StdioServerParams(command="uvx", args=["mcp-server-fetch"])
+    fetcher = await mcp_server_tools(fetch_mcp_server)
+
+    # Create assistant agent
+    model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+    agent = AssistantAgent(name="fetcher", model_client=model_client, tools=fetcher, reflect_on_tool_use=True)
+
+    # Use the tool
+    result = await agent.run(task="Review edwarddonner.com and summarize what you learn. Reply in Markdown.")
+    print(result.messages[-1].content)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/5_autogen/community_contributions/2_lab2_mcp_work_around/readme.md
+++ b/5_autogen/community_contributions/2_lab2_mcp_work_around/readme.md
@@ -1,0 +1,64 @@
+# ✅ Workaround for MCP in Autogen Lab 2 on Windows
+
+Running MCP-based tools in **Jupyter Notebook** on Windows often causes this error:
+
+```
+
+UnsupportedOperation: fileno
+
+````
+
+This is due to limitations in how subprocesses and `fileno()` work inside notebook environments on Windows.
+
+---
+
+## 🛠️ Workaround: Run MCP in a `.py` script
+
+Follow these steps to run your MCP tool using a standalone script instead of a notebook:
+
+---
+
+### 1️⃣ Start the MCP Server (in a separate terminal)
+
+Run the following command **in a new terminal**:
+
+```bash
+uvx mcp-server-fetch
+````
+
+This launches the MCP server in stdio mode (no need for extra flags). Keep this terminal open.
+
+---
+
+### 2️⃣ Run the Python Script (in another terminal)
+
+In a second terminal, run the MCP script using:
+
+```bash
+uv run mcp_fetch.py
+```
+
+> You can also use `python mcp_fetch.py` if you've already activated your virtual environment.
+
+---
+
+### ✅ Expected Output (Example)
+
+```markdown
+# Summary of edwarddonner.com
+
+- Edward Donner is a software engineer...
+- Co-founder of Nebula.io...
+- Offers AI-related events and workshops...
+
+TERMINATE
+```
+
+---
+
+### 💡 Notes
+
+* You **must** start the MCP server before running the Python script.
+* This workaround avoids subprocess issues that commonly occur in Windows Jupyter environments.
+
+---


### PR DESCRIPTION
Hi Ed,

I found a workaround for running MCP in Lab 2 of Autogen in windows environment. I created a separate `.py` script for the MCP-related code to avoid the `fileno` error seen in Jupyter notebooks.

The workflow is as follows:
1. Start the MCP server in a separate terminal using: `uvx mcp-server-fetch`
2. Then, in another terminal, run the MCP script using: `uv run mcp_fetch.py`

The LLM’s output will be printed directly in the terminal.

Along with the `.py` script, I’ve also added a `README.md` with clear instructions for this workaround. Hopefully, this helps other students facing the same issue.

Best,  
Benjamin

 