### PR TITLE
Fix: Add alpha_client.py to make it work using streamable_http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#Custom added .gitignore for agents project
+.env
+.venv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/6_mcp/3_lab3.ipynb
+++ b/6_mcp/3_lab3.ipynb
@@ -11,9 +11,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from dotenv import load_dotenv\n",
     "from agents import Agent, Runner, trace\n",
@@ -53,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,19 +175,151 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## And now the third type: running remotely\n",
+    "### And now the third time: running remotely\n",
     "\n",
-    "It's actually really hard to find a \"remote MCP server\" aka \"hosted MCP server\" aka \"managed MCP server\".\n",
+    "Note that as of June 6th 2025, Smithery's documentation is suggesting to use HTTP streaming instead of WebSockets, accordingly alpha_client.py file has been updated. Only a small change is there in the file, instead of websockets now we are using http streaming. \n",
     "\n",
-    "It's not a common model for using or sharing MCP servers, and there isn't a standard way to discover remote MCP servers.\n",
+    "Reference: \n",
+    "https://smithery.ai/server/@qubaomingg/stock-analysis-mcp/api\n",
     "\n",
-    "Anthropic lists some remote MCP servers, but these are for paid applications with business users:\n",
+    "The remote server is:\n",
     "\n",
-    "https://docs.anthropic.com/en/docs/agents-and-tools/remote-mcp-servers\n",
+    "https://smithery.ai/server/@qubaomingg/stock-analysis-mcp\n",
     "\n",
-    "CloudFlare has tooling for you to create and deploy your own remote MCP servers, but this does not seem to be a common practice:\n",
+    "First we need to set up a free Share Price account with AlphaVantage at:\n",
     "\n",
-    "https://developers.cloudflare.com/agents/guides/remote-mcp-server/\n"
+    "https://www.alphavantage.co/\n",
+    "\n",
+    "Click \"Get Free API Key\"\n",
+    "\n",
+    "And enter that in your .env as `ALPHA_VANTAGE_API_KEY`\n",
+    "\n",
+    "You also need to create a Smithery account at:\n",
+    "\n",
+    "https://smithery.ai\n",
+    "\n",
+    "And create a new free API key, and enter that in your .env as `SMITHERY_API_KEY`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import base64\n",
+    "\n",
+    "alpha_vantage_api_key = os.getenv(\"ALPHA_VANTAGE_API_KEY\")\n",
+    "smithery_api_key = os.getenv(\"SMITHERY_API_KEY\")\n",
+    "\n",
+    "config = {\"alphaVantageApiKey\": alpha_vantage_api_key}\n",
+    "config_b64 = base64.b64encode(json.dumps(config).encode()).decode()\n",
+    "url = f\"wss://server.smithery.ai/@qubaomingg/stock-analysis-mcp/ws?config={config_b64}&api_key={smithery_api_key}\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Difficulties with the OpenAI Agents SDK SSE Client\n",
+    "\n",
+    "This code should work (I believe) but it didn't!\n",
+    "\n",
+    "```\n",
+    "params = {\"url\": url}\n",
+    "async with MCPServerSse(params=params) as server:\n",
+    "    mcp_tools = await server.list_tools()\n",
+    "```\n",
+    "\n",
+    "So I wrote a quick client myself - see financial_datasets_client.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from alpha_client import get_stock_tools_openai\n",
+    "openai_tools = await get_stock_tools_openai()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[FunctionTool(name='get-stock-data', description='get stock data', params_json_schema={'type': 'object', 'properties': {'symbol': {'type': 'string', 'description': 'Stock symbol (e.g., IBM, AAPL)'}}, 'required': ['symbol'], 'additionalProperties': False, '$schema': 'http://json-schema.org/draft-07/schema#'}, on_invoke_tool=<function get_stock_tools_openai.<locals>.<lambda> at 0x10e506840>, strict_json_schema=True),\n",
+       " FunctionTool(name='get-stock-alerts', description='get stock alerts', params_json_schema={'type': 'object', 'properties': {'symbol': {'type': 'string', 'description': 'Stock symbol (e.g., IBM, AAPL)'}}, 'required': ['symbol'], 'additionalProperties': False, '$schema': 'http://json-schema.org/draft-07/schema#'}, on_invoke_tool=<function get_stock_tools_openai.<locals>.<lambda> at 0x10e568ae0>, strict_json_schema=True),\n",
+       " FunctionTool(name='get-daily-stock-data', description='get daily stock data', params_json_schema={'type': 'object', 'properties': {'symbol': {'type': 'string', 'description': 'Stock symbol (e.g., IBM, AAPL)'}}, 'required': ['symbol'], 'additionalProperties': False, '$schema': 'http://json-schema.org/draft-07/schema#'}, on_invoke_tool=<function get_stock_tools_openai.<locals>.<lambda> at 0x10e569620>, strict_json_schema=True)]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openai_tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instructions = \"You can use tools to get stock prices.\"\n",
+    "request = f\"Please let me know the share price of Amazon.\"\n",
+    "model = \"gpt-4o-mini\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calling get-stock-data with {'symbol': 'AMZN'}\n",
+      "Result: meta=None content=[TextContent(type='text', text='Stock data for AMZN (5min intervals):\\n\\n2025-06-05 19:55:00:\\n  Open: 208.2000\\n  High: 208.3000\\n  Low: 207.9200\\n  Close: 208.0100\\n  Volume: 6899\\n\\n2025-06-05 19:50:00:\\n  Open: 208.1500\\n  High: 208.2400\\n  Low: 208.0000\\n  Close: 208.1750\\n  Volume: 9081\\n\\n2025-06-05 19:45:00:\\n  Open: 207.9600\\n  High: 208.1200\\n  Low: 207.8500\\n  Close: 208.0600\\n  Volume: 7033\\n\\n2025-06-05 19:40:00:\\n  Open: 207.8400\\n  High: 208.0000\\n  Low: 207.8000\\n  Close: 207.9700\\n  Volume: 3441\\n\\n2025-06-05 19:35:00:\\n  Open: 207.8500\\n  High: 208.0300\\n  Low: 207.7000\\n  Close: 207.8400\\n  Volume: 12412\\n\\n2025-06-05 19:30:00:\\n  Open: 207.8700\\n  High: 207.9000\\n  Low: 207.7000\\n  Close: 207.8025\\n  Volume: 2682\\n\\n2025-06-05 19:25:00:\\n  Open: 207.8100\\n  High: 207.9600\\n  Low: 207.7000\\n  Close: 207.8000\\n  Volume: 5364\\n\\n2025-06-05 19:20:00:\\n  Open: 207.6900\\n  High: 207.8900\\n  Low: 207.6900\\n  Close: 207.7000\\n  Volume: 1443\\n\\n2025-06-05 19:15:00:\\n  Open: 207.8963\\n  High: 207.9000\\n  Low: 207.6700\\n  Close: 207.7900\\n  Volume: 4988\\n\\n2025-06-05 19:10:00:\\n  Open: 207.7500\\n  High: 207.9000\\n  Low: 207.6500\\n  Close: 207.8100\\n  Volume: 1332\\n\\n... and 90 more data points available.\\n', annotations=None)] isError=False\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The current share price of Amazon (AMZN) is approximately **$208.01**. \n",
+       "\n",
+       "If you need more detailed information or historical data, feel free to ask!"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "agent = Agent(name=\"agent\", instructions=instructions, model=model, tools=openai_tools)\n",
+    "with trace(\"conversation\"):\n",
+    "    result = await Runner.run(agent, request)\n",
+    "display(Markdown(result.final_output))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### As usual, check out the trace:\n",
+    "\n",
+    "https://platform.openai.com/traces"
    ]
   },
   {
@@ -229,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/6_mcp/alpha_client.py
+++ b/6_mcp/alpha_client.py
@@ -1,0 +1,50 @@
+import mcp
+from mcp.client.streamable_http import streamablehttp_client
+from agents import FunctionTool
+import json
+import base64
+import os
+
+config = {
+  "alphaVantageApiKey": os.getenv("ALPHA_VANTAGE_API_KEY")
+}
+# Encode config in base64
+config_b64 = base64.b64encode(json.dumps(config).encode())
+smithery_api_key = os.getenv("SMITHERY_API_KEY")
+
+# Create server URL
+url = f"https://server.smithery.ai/@qubaomingg/stock-analysis-mcp/mcp?config={config_b64}&api_key={smithery_api_key}"
+
+# Create a streamable HTTP client for the MCP server
+# This allows us to use the MCP client with a streamable HTTP connection
+async def list_stock_tools():
+    async with streamablehttp_client(url) as (read_stream, write_stream, _):
+        async with mcp.ClientSession(read_stream, write_stream) as session:
+            # Initialize the connection
+            await session.initialize()
+            tools_result = await session.list_tools()
+            return tools_result.tools
+        
+async def call_stock_tool(tool_name, tool_args):
+    print(f"Calling {tool_name} with {tool_args}")
+    async with streamablehttp_client(url) as (read_stream, write_stream, _):
+        async with mcp.ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, tool_args)
+            print(f"Result: {result}")
+            return result
+        
+async def get_stock_tools_openai():
+    openai_tools = []
+    for tool in await list_stock_tools():
+        schema = {**tool.inputSchema, "additionalProperties": False}
+        schema["properties"] = {"symbol":schema["properties"]["symbol"]}
+        openai_tool = FunctionTool(
+            name=tool.name,
+            description=tool.name.replace("-", " "),
+            params_json_schema=schema,
+            on_invoke_tool=lambda ctx, args, toolname=tool.name: call_stock_tool(toolname, json.loads(args))
+                
+        )
+        openai_tools.append(openai_tool)
+    return openai_tools


### PR DESCRIPTION
Re-added the alpha_client.py file and modified it to align with Smithery’s documentation. Replaced WebSocket implementation with streamable HTTP, as recommended.

Additionally, updated the relevant section in Lab 3 of the MCP Week to demonstrate how to run MCP servers remotely using this setup.

Please take a look at the changes whenever you get a chance.