### PR TITLE
Enabling google search tool for deep research

### DIFF
--- a/2_openai/community_contributions/deep_research_using_google_search/README.md
+++ b/2_openai/community_contributions/deep_research_using_google_search/README.md
@@ -1,0 +1,6 @@
+---
+title: deep_research using google_search
+app_file: deep_research.py
+sdk: gradio
+sdk_version: 5.31.0
+---

--- a/2_openai/community_contributions/deep_research_using_google_search/deep_research.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/deep_research.py
@@ -1,0 +1,23 @@
+import gradio as gr
+from dotenv import load_dotenv
+from research_manager import ResearchManager
+
+load_dotenv(override=True)
+
+
+async def run(query: str):
+    async for chunk in ResearchManager().run(query):
+        yield chunk
+
+
+with gr.Blocks(theme=gr.themes.Default(primary_hue="sky")) as ui:
+    gr.Markdown("# Deep Research")
+    query_textbox = gr.Textbox(label="What topic would you like to research?")
+    run_button = gr.Button("Run", variant="primary")
+    report = gr.Markdown(label="Report")
+    
+    run_button.click(fn=run, inputs=query_textbox, outputs=report)
+    query_textbox.submit(fn=run, inputs=query_textbox, outputs=report)
+
+ui.launch(inbrowser=True)
+

--- a/2_openai/community_contributions/deep_research_using_google_search/email_agent.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/email_agent.py
@@ -1,0 +1,29 @@
+import os
+from typing import Dict
+
+import sendgrid
+from sendgrid.helpers.mail import Email, Mail, Content, To
+from agents import Agent, function_tool
+
+@function_tool
+def send_email(subject: str, html_body: str) -> Dict[str, str]:
+    """ Send an email with the given subject and HTML body """
+    sg = sendgrid.SendGridAPIClient(api_key=os.environ.get('SENDGRID_API_KEY'))
+    from_email = Email("subbu.sw@gmail.com") # put your verified sender here
+    to_email = To("subbu@shopalyst.com") # put your recipient here
+    content = Content("text/html", html_body)
+    mail = Mail(from_email, to_email, subject, content).get()
+    response = sg.client.mail.send.post(request_body=mail)
+    print("Email response", response.status_code)
+    return {"status": "success"}
+
+INSTRUCTIONS = """You are able to send a nicely formatted HTML email based on a detailed report.
+You will be provided with a detailed report. You should use your tool to send one email, providing the 
+report converted into clean, well presented HTML with an appropriate subject line."""
+
+email_agent = Agent(
+    name="Email agent",
+    instructions=INSTRUCTIONS,
+    tools=[send_email],
+    model="gpt-4o-mini",
+)

--- a/2_openai/community_contributions/deep_research_using_google_search/google_search_agent.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/google_search_agent.py
@@ -1,0 +1,53 @@
+import os
+from pprint import pprint
+from dotenv import load_dotenv
+from bs4 import BeautifulSoup
+import requests
+from agents import function_tool
+from googleapiclient.discovery import build
+from pydantic import BaseModel, Field
+
+load_dotenv(override=True)
+api_key=os.environ.get('GOOGLE_SEARCH_API_KEY')
+search_context=os.environ.get('GOOGLE_SEARCH_CONTEXT')
+
+class SearchResult(BaseModel):
+    title: str = Field(description="The title of the search result.")
+    link: str = Field(description="The URL of the search result.")
+    content: str = Field(description="The content snippet of the search result.")
+
+class SearchResults(BaseModel):
+    results: list[SearchResult] = Field(description="A list of search results.")
+
+def fetch_page_content(url):
+    try:
+        page = requests.get(url, timeout=10)
+        soup = BeautifulSoup(page.content, 'html.parser')
+        text = soup.get_text()
+        return text[:2000]  # Return first 1000 characters
+    except Exception as e:
+        return f"Error fetching {url}: {str(e)}"
+
+
+@function_tool
+def run_google_search(query:str) -> list[dict[str, str]]:
+    """ Run a Google search and return the results """
+    search_results = SearchResults(results=[])
+    service = build("customsearch", "v1", developerKey=api_key)
+    res = (
+        service.cse()
+        .list(
+            q=f'{query}',
+            cx=f'{search_context}',
+        )
+        .execute()
+    )
+
+    for item in res.get('items', []):
+        content = fetch_page_content(item['link'])
+        search_results.results.append(SearchResult(
+            title=item.get('title', ''),
+            link=item.get('link', ''),
+            content=content
+        ))
+    return search_results

--- a/2_openai/community_contributions/deep_research_using_google_search/llm_as_judge.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/llm_as_judge.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pydantic import BaseModel, Field
+from agents import Agent, ItemHelpers, Runner, TResponseInputItem, trace
+
+"""
+This example shows the LLM as a judge pattern. The first agent generates an outline for a story.
+The second agent judges the outline and provides feedback. We loop until the judge is satisfied
+with the outline.
+"""
+
+story_outline_generator = Agent(
+    name="story_outline_generator",
+    instructions=(
+        "You generate a very short story outline based on the user's input."
+        "If there is any feedback provided, use it to improve the outline."
+    ),
+    model="gpt-4o-mini",
+)
+
+
+class EvaluationFeedback(BaseModel):
+    """The feedback from the evaluator on the story outline."""
+    feedback: str
+    # score: Literal["pass", "needs_improvement", "fail"]
+    score: int = Field(
+        description="Score for the outline, 0-10. 0 means fail, ge 7 means pass.",
+        ge=0,
+        le=10,
+    )
+
+evaluator = Agent[None](
+    name="evaluator",
+    instructions=(
+        "You evaluate a story outline and decide if it's good enough."
+        "If it's not good enough, you provide feedback on what needs to be improved."
+        "Never give it a pass on the first try."
+    ),
+    output_type=EvaluationFeedback,
+    model="gpt-4o-mini",
+)
+
+
+async def main() -> None:
+    msg = input("What kind of story would you like to hear? ")
+    input_items: list[TResponseInputItem] = [{"content": msg, "role": "user"}]
+
+    latest_outline: str | None = None
+    num_iterations: int = 0
+
+    # We'll run the entire workflow in a single trace
+    with trace("LLM as a judge"):
+        while True and num_iterations < 5:
+            num_iterations += 1
+            print(f"Iteration {num_iterations}")
+            story_outline_result = await Runner.run(
+                story_outline_generator,
+                input_items,
+            )
+
+            input_items = story_outline_result.to_input_list()
+            latest_outline = ItemHelpers.text_message_outputs(story_outline_result.new_items)
+            print("Story outline generated")
+
+            evaluator_result = await Runner.run(evaluator, input_items)
+            result: EvaluationFeedback = evaluator_result.final_output
+
+            print(f"Evaluator score: {result.score}")
+
+            if result.score >= 7:
+                print("Story outline is good enough, exiting.")
+                break
+
+            print("Re-running with feedback")
+
+            input_items.append({"content": f"Feedback: {result.feedback}", "role": "user"})
+
+    print(f"Final story outline: {latest_outline}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/2_openai/community_contributions/deep_research_using_google_search/planner_agent.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/planner_agent.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, Field
+from agents import Agent
+
+HOW_MANY_SEARCHES = 5
+
+INSTRUCTIONS = f"You are a helpful research assistant. Given a query, come up with a set of web searches \
+to perform to best answer the query. Output {HOW_MANY_SEARCHES} terms to query for."
+
+
+class WebSearchItem(BaseModel):
+    reason: str = Field(description="Your reasoning for why this search is important to the query.")
+    query: str = Field(description="The search term to use for the web search.")
+
+
+class WebSearchPlan(BaseModel):
+    searches: list[WebSearchItem] = Field(description="A list of web searches to perform to best answer the query.")
+    
+planner_agent = Agent(
+    name="PlannerAgent",
+    instructions=INSTRUCTIONS,
+    model="gpt-4o-mini",
+    output_type=WebSearchPlan,
+)

--- a/2_openai/community_contributions/deep_research_using_google_search/research_manager.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/research_manager.py
@@ -1,0 +1,84 @@
+from agents import Runner, trace, gen_trace_id
+from search_agent import search_agent
+from planner_agent import planner_agent, WebSearchItem, WebSearchPlan
+from writer_agent import writer_agent, ReportData
+from email_agent import email_agent
+import asyncio
+
+class ResearchManager:
+
+    async def run(self, query: str):
+        """ Run the deep research process, yielding the status updates and the final report"""
+        trace_id = gen_trace_id()
+        with trace("Research trace", trace_id=trace_id):
+            print(f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}")
+            yield f"View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}"
+            print("Starting research...")
+            search_plan = await self.plan_searches(query)
+            yield "Searches planned, starting to search..."     
+            search_results = await self.perform_searches(search_plan)
+            yield "Searches complete, writing report..."
+            report = await self.write_report(query, search_results)
+            yield "Report written, sending email..."
+            await self.send_email(report)
+            yield "Email sent, research complete"
+            yield report.markdown_report
+        
+
+    async def plan_searches(self, query: str) -> WebSearchPlan:
+        """ Plan the searches to perform for the query """
+        print("Planning searches...")
+        result = await Runner.run(
+            planner_agent,
+            f"Query: {query}",
+        )
+        print(f"Will perform {len(result.final_output.searches)} searches")
+        return result.final_output_as(WebSearchPlan)
+
+    async def perform_searches(self, search_plan: WebSearchPlan) -> list[str]:
+        """ Perform the searches to perform for the query """
+        print("Searching...")
+        num_completed = 0
+        tasks = [asyncio.create_task(self.search(item)) for item in search_plan.searches]
+        results = []
+        for task in asyncio.as_completed(tasks):
+            result = await task
+            if result is not None:
+                results.append(result)
+            num_completed += 1
+            print(f"Searching... {num_completed}/{len(tasks)} completed")
+        print("Finished searching")
+        return results
+
+    async def search(self, item: WebSearchItem) -> str | None:
+        """ Perform a search for the query """
+        input = f"Search term: {item.query}\nReason for searching: {item.reason}"
+        try:
+            result = await Runner.run(
+                search_agent,
+                input,
+            )
+            return str(result.final_output)
+        except Exception:
+            return None
+
+    async def write_report(self, query: str, search_results: list[str]) -> ReportData:
+        """ Write the report for the query """
+        print("Thinking about report...")
+        input = f"Original query: {query}\nSummarized search results: {search_results}"
+        result = await Runner.run(
+            writer_agent,
+            input,
+        )
+
+        print("Finished writing report")
+        return result.final_output_as(ReportData)
+    
+    async def send_email(self, report: ReportData) -> None:
+        print("Writing email...")
+        result = await Runner.run(
+            email_agent,
+            report.markdown_report,
+        )
+        print("Email sent")
+        return report

--- a/2_openai/community_contributions/deep_research_using_google_search/search_agent.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/search_agent.py
@@ -1,0 +1,19 @@
+from agents import Agent, WebSearchTool, ModelSettings
+from google_search_agent import run_google_search
+
+
+INSTRUCTIONS = (
+    "You are a research assistant. Given a search term, you search the web for that term and "
+    "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300 "
+    "words. Capture the main points. Write succintly, no need to have complete sentences or good "
+    "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the "
+    "essence and ignore any fluff. Do not include any additional commentary other than the summary itself."
+)
+
+search_agent = Agent(
+    name="Search agent",
+    instructions=INSTRUCTIONS,
+    tools=[run_google_search],
+    model="gpt-4o-mini",
+    model_settings=ModelSettings(tool_choice="required"),
+)

--- a/2_openai/community_contributions/deep_research_using_google_search/writer_agent.py
+++ b/2_openai/community_contributions/deep_research_using_google_search/writer_agent.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+from agents import Agent
+
+INSTRUCTIONS = (
+    "You are a senior researcher tasked with writing a cohesive report for a research query. "
+    "You will be provided with the original query, and some initial research done by a research assistant.\n"
+    "You should first come up with an outline for the report that describes the structure and "
+    "flow of the report. Then, generate the report and return that as your final output.\n"
+    "The final output should be in markdown format, and it should be lengthy and detailed. Aim "
+    "for 5-10 pages of content, at least 1000 words."
+)
+
+
+class ReportData(BaseModel):
+    short_summary: str = Field(description="A short 2-3 sentence summary of the findings.")
+
+    markdown_report: str = Field(description="The final report")
+
+    follow_up_questions: list[str] = Field(description="Suggested topics to research further")
+
+
+writer_agent = Agent(
+    name="WriterAgent",
+    instructions=INSTRUCTIONS,
+    model="gpt-4o-mini",
+    output_type=ReportData,
+)


### PR DESCRIPTION
The deep research Agent is very useful to research and summarise information from the internet. Here is a pull request that utilises google search instead of openai's hosted tool to search for the info. This reduces cost significantly and you can now use this tool for personal summaries and research. 

I have used the python sample from google custom search JSON API (details [here](https://developers.google.com/custom-search/v1/libraries)) to build this tool. You will need to create a google search API key and search context and add it to the .env file before starting to use the google custom search JSON API.

```
GOOGLE_SEARCH_API_KEY=
GOOGLE_SEARCH_CONTEXT=
```

With this tool, depending on your google search API usage quota, you should get to do upto 100 free searches a day.