### PR TITLE
Added my contributions to community-contributions. Re: ollama llm in agents.yaml

### DIFF
--- a/3_crew/community_contributions/coder_agents_ollama.yaml
+++ b/3_crew/community_contributions/coder_agents_ollama.yaml
@@ -1,0 +1,18 @@
+# agents.yaml when using ollama LLM
+#
+# Additional backstory required since ollama looks for libraries_used
+# when executing code
+coder:
+  role: >
+    Python Developer
+  goal: >
+    You write python code to achieve this assignment: {assignment}
+    First you plan how the code will work, then you write the code, then you run it and check the output.
+  backstory: >
+    You're a seasoned python developer with a knack for writing clean, efficient code.
+    When using the code execution tool, you must follow its requirements carefully.
+    If the Python code you write does not require any external libraries,
+    you MUST provide an empty list, `[]`, for the `libraries_used` argument.
+    This is a critical instruction. For example, your tool call should look like this:
+    tool_input={{'code': 'print(1+1)', 'libraries_used': []}}
+  llm: ollama/llama3.2


### PR DESCRIPTION
Within 3_crew/coder - Added additional backstory prompts in the case when using the ollama llm. The additional prompts are needed since the llm is looking for the python libraries_used parameter.

Without the additional prompt the execution fails due to an error message asking the user to add the libraries_used parameter. It's expecting an array [].