### PR TITLE
Refactor notification system to use Discord webhooks instead of Pushover

### DIFF
--- a/1_foundations/app.py
+++ b/1_foundations/app.py
@@ -9,15 +9,17 @@ import gradio as gr
 
 load_dotenv(override=True)
 
-def push(text):
-    requests.post(
-        "https://api.pushover.net/1/messages.json",
-        data={
-            "token": os.getenv("PUSHOVER_TOKEN"),
-            "user": os.getenv("PUSHOVER_USER"),
-            "message": text,
-        }
-    )
+discord_webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
+
+if discord_webhook_url:
+    print(f"Discord webhook URL found and starts with {discord_webhook_url[0]}")
+else:
+    print("Discord webhook URL not found")
+
+def push(message):
+    print(f"Discord: {message}")
+    payload = {"content": message}
+    requests.post(discord_webhook_url, data=payload)
 
 
 def record_user_details(email, name="Name not provided", notes="not provided"):

--- a/1_foundations/community_contributions/discord_over_pushover/README.md
+++ b/1_foundations/community_contributions/discord_over_pushover/README.md
@@ -1,0 +1,38 @@
+## Reason
+
+I wanted to receive notifications even after 30 days. That's why I decided to use discord webhooks instead of pushover. The code is not much different.
+
+Steps:
+
+1. Open discord and create a new channel in the server you want to do this in.
+2. Go to `Edit Channel (gear icon)` -> `Integrations` -> `Create Webhook`.
+3. Create a new webhook and give it a name.
+4. Copy the webhook URL.
+5. Replace pushover environment variables with `DISCORD_WEBHOOK_URL`.
+
+Just instead of 
+```py
+requests.post(
+        "https://api.pushover.net/1/messages.json",
+        data={
+            "token": os.getenv("PUSHOVER_TOKEN"),
+            "user": os.getenv("PUSHOVER_USER"),
+            "message": text,
+        }
+    )
+```
+
+We use 
+```py
+discord_webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
+
+if discord_webhook_url:
+    print(f"Discord webhook URL found and starts with {discord_webhook_url[0]}")
+else:
+    print("Discord webhook URL not found")
+
+def push(message):
+    print(f"Discord: {message}")
+    payload = {"content": message}
+    requests.post(discord_webhook_url, data=payload)
+```


### PR DESCRIPTION
This pull request replaces the use of Pushover notifications with Discord webhooks for sending messages. The changes include updating the notification logic in the code and providing documentation on how to configure Discord webhooks.

### Code changes:
* Replaced the `push` function in `1_foundations/app.py` to use Discord webhooks instead of Pushover. The new implementation retrieves the `DISCORD_WEBHOOK_URL` from environment variables, validates its presence, and sends messages using the webhook URL.

### Documentation updates:
* Added a new section in `1_foundations/community_contributions/discord_over_pushover/README.md` explaining the rationale for switching to Discord webhooks, along with step-by-step instructions on how to set up and use Discord webhooks in place of Pushover.