### PR TITLE
use start parameter for enumerate

### DIFF
--- a/1_foundations/2_lab2.ipynb
+++ b/1_foundations/2_lab2.ipynb
@@ -406,9 +406,9 @@
     "\n",
     "results_dict = json.loads(results)\n",
     "ranks = results_dict[\"results\"]\n",
-    "for index, result in enumerate(ranks):\n",
+    "for index, result in enumerate(ranks, start=1):\n",
     "    competitor = competitors[int(result)-1]\n",
-    "    print(f\"Rank {index+1}: {competitor}\")"
+    "    print(f\"Rank {index}: {competitor}\")"
    ]
   },
   {


### PR DESCRIPTION
The enumerate function has a parameter 'start' which can make the range start at 1, cleaner and better performance than adding 1 every time during the loop.