### PR TITLE
Add Date MCP server+client with tutorial under community_contributions

### DIFF
--- a/6_mcp/community_contributions/date_mcp_server_client/README.md
+++ b/6_mcp/community_contributions/date_mcp_server_client/README.md
@@ -1,0 +1,37 @@
+# Date MCP Server + Client
+
+A minimal Model Context Protocol (MCP) server that exposes a single tool `current_date` returning today's date in ISO format, and a matching client that lists tools and invokes it.
+
+## Files
+- `date_server.py`: MCP server exposing `current_date`
+- `date_client.py`: Client helpers using stdio to connect via `uv`
+- `date_tutorial.ipynb`: Walkthrough notebook to try it end-to-end
+
+## Prereqs
+- `uv` available on your PATH
+
+## Quickstart
+```bash
+cd 6_mcp/community_contributions/date_mcp_server_client
+uv run python - << 'PY'
+import asyncio
+from date_client import list_date_tools, call_date_tool
+async def main():
+    tools = await list_date_tools()
+    print('Tools:', [t.name for t in tools])
+    res = await call_date_tool('current_date')
+    contents = getattr(res, 'content', None) or getattr(res, 'contents', None)
+    if contents:
+        vals = []
+        for c in contents:
+            vals.append(getattr(c, 'text', None) or getattr(c, 'value', None) or str(c))
+        print('Result:', ' '.join(vals))
+    else:
+        print('Raw result:', res)
+asyncio.run(main())
+PY
+```
+
+You can also open the `date_tutorial.ipynb` notebook and run the cells.
+
+

--- a/6_mcp/community_contributions/date_mcp_server_client/date_client.py
+++ b/6_mcp/community_contributions/date_mcp_server_client/date_client.py
@@ -1,0 +1,24 @@
+import mcp
+from mcp.client.stdio import stdio_client
+from mcp import StdioServerParameters
+
+
+params = StdioServerParameters(command="uv", args=["run", "date_server.py"], env=None)
+
+
+async def list_date_tools():
+    async with stdio_client(params) as streams:
+        async with mcp.ClientSession(*streams) as session:
+            await session.initialize()
+            tools_result = await session.list_tools()
+            return tools_result.tools
+
+
+async def call_date_tool(tool_name, tool_args=None):
+    async with stdio_client(params) as streams:
+        async with mcp.ClientSession(*streams) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, tool_args or {})
+            return result
+
+

--- a/6_mcp/community_contributions/date_mcp_server_client/date_server.py
+++ b/6_mcp/community_contributions/date_mcp_server_client/date_server.py
@@ -1,0 +1,17 @@
+from datetime import date
+from mcp.server.fastmcp import FastMCP
+
+
+mcp = FastMCP("date_server")
+
+
+@mcp.tool()
+async def current_date() -> str:
+    """Return today's date in ISO format (YYYY-MM-DD)."""
+    return date.today().isoformat()
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+
+

--- a/6_mcp/community_contributions/date_mcp_server_client/date_tutorial.ipynb
+++ b/6_mcp/community_contributions/date_mcp_server_client/date_tutorial.ipynb
@@ -1,0 +1,78 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Date MCP Server + Client Tutorial\n",
+        "\n",
+        "This notebook demonstrates a minimal MCP server exposing `current_date` and a matching client that calls it.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os, shutil\n",
+        "os.chdir('/home/sergei/projects/ai-agents-course/6_mcp/community_contributions/date_mcp_server_client')\n",
+        "print('CWD:', os.getcwd())\n",
+        "print('uv path:', shutil.which('uv'))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Show server and client code\n",
+        "from pathlib import Path\n",
+        "print('--- date_server.py ---')\n",
+        "print(Path('date_server.py').read_text())\n",
+        "print('\\n--- date_client.py ---')\n",
+        "print(Path('date_client.py').read_text())\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# List tools\n",
+        "from date_client import list_date_tools\n",
+        "\n",
+        "[t.name for t in (await list_date_tools())]\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Call current_date\n",
+        "from date_client import call_date_tool\n",
+        "\n",
+        "res = await call_date_tool('current_date')\n",
+        "contents = getattr(res, 'content', None) or getattr(res, 'contents', None)\n",
+        "if contents:\n",
+        "    vals = []\n",
+        "    for c in contents:\n",
+        "        vals.append(getattr(c, 'text', None) or getattr(c, 'value', None) or str(c))\n",
+        "    ' '.join(vals)\n",
+        "else:\n",
+        "    res\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
Add Date MCP server and client with tutorial (community_contributions)

- **What**
  - Adds a minimal MCP server and matching client exposing a `current_date` tool.
  - Includes a runnable tutorial notebook and README under community contributions.

- **Why**
  - Provide a simple, reproducible example for students to learn MCP server/client patterns.
  - Useful as a template for building custom MCP tools.

- **How**
  - Server: `FastMCP` over stdio via `uv`, tool `current_date` returns today’s date (ISO).
  - Client: connects via stdio, lists tools, and calls `current_date`.
  - Notebook uses top-level await to call the tool from Jupyter.

- **Files added**
  - `6_mcp/community_contributions/date_mcp_server_client/date_server.py`
  - `6_mcp/community_contributions/date_mcp_server_client/date_client.py`
  - `6_mcp/community_contributions/date_mcp_server_client/README.md`
  - `6_mcp/community_contributions/date_mcp_server_client/date_tutorial.ipynb`

- **How to test**
  - Notebook: open `6_mcp/community_contributions/date_mcp_server_client/date_tutorial.ipynb` and run all cells.
  - CLI:
    ```bash
    cd 6_mcp/community_contributions/date_mcp_server_client
    uv run python - << 'PY'
    import asyncio
    from date_client import list_date_tools, call_date_tool
    async def main():
        tools = await list_date_tools()
        print('Tools:', [t.name for t in tools])
        res = await call_date_tool('current_date')
        contents = getattr(res, 'content', None) or getattr(res, 'contents', None)
        if contents:
            vals = []
            for c in contents:
                vals.append(getattr(c, 'text', None) or getattr(c, 'value', None) or str(c))
            print('Result:', ' '.join(vals))
        else:
            print('Raw result:', res)
    asyncio.run(main())
    PY
    ```

- **Impact**
  - Isolated to `community_contributions`; no changes to core code.

- **Checklist**
  - [x] Notebook runs end-to-end locally
  - [x] Lints clean
  - [x] Follows existing contribution structure
  - [ ] Ready for review