### PR TITLE
Fix for file system not working in windows

### DIFF
--- a/4_langgraph/community_contributions/sidekick_tools.py
+++ b/4_langgraph/community_contributions/sidekick_tools.py
@@ -1,15 +1,16 @@
-import os
-
-import requests
+from playwright.async_api import async_playwright
+from langchain_community.agent_toolkits import PlayWrightBrowserToolkit
 from dotenv import load_dotenv
+import os
+import requests
 from langchain.agents import Tool
-from langchain_community.agent_toolkits import (FileManagementToolkit,
-                                                PlayWrightBrowserToolkit)
+from langchain_community.agent_toolkits import FileManagementToolkit
 from langchain_community.tools.wikipedia.tool import WikipediaQueryRun
+from langchain_experimental.tools import PythonREPLTool
 from langchain_community.utilities import GoogleSerperAPIWrapper
 from langchain_community.utilities.wikipedia import WikipediaAPIWrapper
-from langchain_experimental.tools import PythonREPLTool
-from playwright.async_api import async_playwright
+
+
 
 load_dotenv(override=True)
 pushover_token = os.getenv("PUSHOVER_TOKEN")
@@ -31,7 +32,8 @@ def push(text: str):
 
 
 def get_file_tools():
-    toolkit = FileManagementToolkit(root_dir="sandbox")
+    sandbox_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sandbox")
+    toolkit = FileManagementToolkit(root_dir=sandbox_dir)
     return toolkit.get_tools()
 
 

--- a/4_langgraph/sidekick_tools.py
+++ b/4_langgraph/sidekick_tools.py
@@ -32,8 +32,7 @@ def push(text: str):
 
 
 def get_file_tools():
-    sandbox_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sandbox")
-    toolkit = FileManagementToolkit(root_dir=sandbox_dir)
+    toolkit = FileManagementToolkit(root_dir="sandbox")
     return toolkit.get_tools()
 
 

--- a/4_langgraph/sidekick_tools.py
+++ b/4_langgraph/sidekick_tools.py
@@ -32,7 +32,8 @@ def push(text: str):
 
 
 def get_file_tools():
-    toolkit = FileManagementToolkit(root_dir="sandbox")
+    sandbox_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sandbox")
+    toolkit = FileManagementToolkit(root_dir=sandbox_dir)
     return toolkit.get_tools()
 
 

--- a/4_langgraph/sidekick_tools.py
+++ b/4_langgraph/sidekick_tools.py
@@ -1,21 +1,22 @@
-import os
-
-import requests
+from playwright.async_api import async_playwright
+from langchain_community.agent_toolkits import PlayWrightBrowserToolkit
 from dotenv import load_dotenv
+import os
+import requests
 from langchain.agents import Tool
-from langchain_community.agent_toolkits import (FileManagementToolkit,
-                                                PlayWrightBrowserToolkit)
+from langchain_community.agent_toolkits import FileManagementToolkit
 from langchain_community.tools.wikipedia.tool import WikipediaQueryRun
+from langchain_experimental.tools import PythonREPLTool
 from langchain_community.utilities import GoogleSerperAPIWrapper
 from langchain_community.utilities.wikipedia import WikipediaAPIWrapper
-from langchain_experimental.tools import PythonREPLTool
-from playwright.async_api import async_playwright
+
 
 load_dotenv(override=True)
 pushover_token = os.getenv("PUSHOVER_TOKEN")
 pushover_user = os.getenv("PUSHOVER_USER")
 pushover_url = "https://api.pushover.net/1/messages.json"
 serper = GoogleSerperAPIWrapper()
+
 
 async def playwright_tools():
     playwright = await async_playwright().start()
@@ -26,7 +27,10 @@ async def playwright_tools():
 
 def push(text: str):
     """Send a push notification to the user"""
-    requests.post(pushover_url, data = {"token": pushover_token, "user": pushover_user, "message": text})
+    requests.post(
+        pushover_url,
+        data={"token": pushover_token, "user": pushover_user, "message": text},
+    )
     return "success"
 
 
@@ -36,19 +40,22 @@ def get_file_tools():
 
 
 async def other_tools():
-    push_tool = Tool(name="send_push_notification", func=push, description="Use this tool when you want to send a push notification")
+    push_tool = Tool(
+        name="send_push_notification",
+        func=push,
+        description="Use this tool when you want to send a push notification",
+    )
     file_tools = get_file_tools()
 
-    tool_search =Tool(
+    tool_search = Tool(
         name="search",
         func=serper.run,
-        description="Use this tool when you want to get the results of an online web search"
+        description="Use this tool when you want to get the results of an online web search",
     )
 
     wikipedia = WikipediaAPIWrapper()
     wiki_tool = WikipediaQueryRun(api_wrapper=wikipedia)
 
     python_repl = PythonREPLTool()
-    
-    return file_tools + [push_tool, tool_search, python_repl,  wiki_tool]
 
+    return file_tools + [push_tool, tool_search, python_repl, wiki_tool]

--- a/4_langgraph/sidekick_tools.py
+++ b/4_langgraph/sidekick_tools.py
@@ -11,12 +11,12 @@ from langchain_community.utilities import GoogleSerperAPIWrapper
 from langchain_community.utilities.wikipedia import WikipediaAPIWrapper
 
 
+
 load_dotenv(override=True)
 pushover_token = os.getenv("PUSHOVER_TOKEN")
 pushover_user = os.getenv("PUSHOVER_USER")
 pushover_url = "https://api.pushover.net/1/messages.json"
 serper = GoogleSerperAPIWrapper()
-
 
 async def playwright_tools():
     playwright = await async_playwright().start()
@@ -27,10 +27,7 @@ async def playwright_tools():
 
 def push(text: str):
     """Send a push notification to the user"""
-    requests.post(
-        pushover_url,
-        data={"token": pushover_token, "user": pushover_user, "message": text},
-    )
+    requests.post(pushover_url, data = {"token": pushover_token, "user": pushover_user, "message": text})
     return "success"
 
 
@@ -40,22 +37,19 @@ def get_file_tools():
 
 
 async def other_tools():
-    push_tool = Tool(
-        name="send_push_notification",
-        func=push,
-        description="Use this tool when you want to send a push notification",
-    )
+    push_tool = Tool(name="send_push_notification", func=push, description="Use this tool when you want to send a push notification")
     file_tools = get_file_tools()
 
-    tool_search = Tool(
+    tool_search =Tool(
         name="search",
         func=serper.run,
-        description="Use this tool when you want to get the results of an online web search",
+        description="Use this tool when you want to get the results of an online web search"
     )
 
     wikipedia = WikipediaAPIWrapper()
     wiki_tool = WikipediaQueryRun(api_wrapper=wikipedia)
 
     python_repl = PythonREPLTool()
+    
+    return file_tools + [push_tool, tool_search, python_repl,  wiki_tool]
 
-    return file_tools + [push_tool, tool_search, python_repl, wiki_tool]


### PR DESCRIPTION
File write tool is not working in windows if repo is stored in folder having space.
Using os path ensures that wherever the repo is stored, it'll run.