### PR TITLE
sach91 bootcamp week6 exercise: MCP with ollama+docker+telegram

### DIFF
--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/Dockerfile.pyrepl
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/Dockerfile.pyrepl
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+# Optional: add a few safe libs you want the REPL to have
+RUN pip install --no-cache-dir numpy sympy
+
+# Create an unprivileged user
+RUN useradd -m -u 1000 sandbox
+USER sandbox
+WORKDIR /home/sandbox
+
+# Keep Python quiet and unbuffered
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/app.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/app.py
@@ -1,0 +1,23 @@
+import gradio as gr
+from dotenv import load_dotenv
+from research_manager import ResearchManager
+
+load_dotenv(override=True)
+
+
+async def run(query: str):
+    async for chunk in ResearchManager().run(query):
+        yield chunk
+
+
+with gr.Blocks(theme=gr.themes.Default(primary_hue="sky")) as ui:
+    gr.Markdown("# Deep Research")
+    query_textbox = gr.Textbox(label="What topic would you like to research?")
+    run_button = gr.Button("Run", variant="primary")
+    report = gr.Markdown(label="Report")
+    
+    run_button.click(fn=run, inputs=query_textbox, outputs=report)
+    query_textbox.submit(fn=run, inputs=query_textbox, outputs=report)
+
+ui.launch(inbrowser=True)
+

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/base_model.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/base_model.py
@@ -1,0 +1,4 @@
+from agents.extensions.models.litellm_model import LitellmModel
+
+ollama_model = LitellmModel(model="ollama/llama3.2", api_key="ollama")
+ollama_model_eval = LitellmModel(model="ollama/llama3.1", api_key="ollama")

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/docker_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/docker_agent.py
@@ -1,0 +1,20 @@
+from agents import Agent, ModelSettings
+from base_model import ollama_model
+from dockertool import run_docker
+
+INSTRUCTIONS = (
+    "Call docker tool only once and provide the response from the docker.\n"
+)
+
+
+# Get docker response either from tool or mcp server as the agent decides.
+def get_docker_agent(mcp_server) -> Agent:
+    ts_agent = Agent(
+        name="DockerAgent",
+        instructions=INSTRUCTIONS,
+        model=ollama_model,
+        tools=[run_docker],
+        mcp_servers=[mcp_server],
+        model_settings=ModelSettings(temperature=0),    # tool_choice="required",
+    )
+    return ts_agent

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/dockertool.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/dockertool.py
@@ -1,0 +1,57 @@
+import subprocess
+from agents import function_tool
+
+g_docker_resp = ''
+
+# For fallback case, due to issues with open source llm
+def get_docker_resp():
+    return g_docker_resp
+
+
+@function_tool
+def run_docker() -> str:  # type: ignore[override]
+    """Run docker tool to get today's date"""
+
+    # Tunables
+    image: str = "pyrepl-sandbox:latest"
+    timeout_s: int = 60
+    mem: str = "256m"
+    cpus: str = "1"
+    pids: int = 128
+    output_limit: int = 1000  # truncate overly long output
+
+    code = 'from datetime import date; print(date.today())'
+    import sys
+    print('Code to run in docker:', code, file=sys.stderr)
+
+    cmd = [
+        "docker", "run", "--rm",
+        "--network", "none", "--read-only",
+        "--cpus", cpus, "--memory", mem,
+        "--pids-limit", str(pids),
+        "--security-opt", "no-new-privileges", "--cap-drop", "ALL",
+        "--tmpfs", "/tmp:rw,noexec,nosuid,size=64m",
+        image, "bash", "-lc", f"python - <<'PYEOF'\n{code}\nPYEOF"
+    ]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return "Execution timed out."
+
+    out = (proc.stdout or "") + (("\n" + proc.stderr) if proc.stderr else "")
+    print('Docker returned:', out, file=sys.stderr)
+    global g_docker_resp
+    g_docker_resp = out
+
+    if len(out) > output_limit:
+        out = out[:output_limit] + "\n... [truncated]"
+    if proc.returncode != 0 and not out:
+        return f"Process exited with code {proc.returncode} and no output."
+    return out.strip() or "(no output)"
+

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/eval_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/eval_agent.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+from agents import Agent
+from base_model import ollama_model_eval
+
+
+INSTRUCTIONS = (
+    "You are a analyst tasked with evaluating the short report for a research query.\n"
+    "You have high quality standards and accept only good quality report. "
+    "You will be provided with the original query and the report.\n"
+    "You should evaluate the quality of the report and tell your judgement as your final output.\n"
+    "The final output should be boolean, that you accept the report or not.\n"
+    "If you do not accept the report, web search will be performed to gather more information."
+    "Note that if the query pertains to recent information, it is better to reject the report and go for web search.\n"
+)
+
+class EvalData(BaseModel):
+    accept: bool = Field(description="You accept the quality of the concise report or not.")
+
+    reason: str = Field(description="The reason for the evaluation.")
+
+
+eval_agent = Agent(
+    name="EvalAgent",
+    instructions=INSTRUCTIONS,
+    model=ollama_model_eval,
+    output_type=EvalData,
+)

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/main_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/main_agent.py
@@ -1,0 +1,18 @@
+from agents import Agent
+from base_model import ollama_model
+from writer_agent import ReportData
+
+INSTRUCTIONS = (
+    "You are a senior researcher tasked with writing a cohesive short report for a research query. "
+    "You will be provided with the original query.\n"
+    "You should generate a concise report and return that as your final output.\n"
+    "The final output should be in text format, and it should be concise, not lengthy or detailed. "
+    "Aim for 2 paragraphs of content, maximum 200 words."
+)
+
+main_agent = Agent(
+    name="MainAgent",
+    instructions=INSTRUCTIONS,
+    model=ollama_model,
+    output_type=ReportData,
+)

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/mcp_server.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/mcp_server.py
@@ -1,0 +1,39 @@
+from mcp.server.fastmcp import FastMCP
+import dockertool
+import searchtool
+import msg_agent
+from typing import List, Dict
+
+mcp = FastMCP("my_mcp_server")
+
+@mcp.tool()
+async def run_docker() -> str:
+    """Run Docker container and return response.
+    """
+    return dockertool.run_docker()
+
+
+@mcp.tool()
+async def web_search(query: str, safe_search: str = "moderate") -> List[Dict[str, str]]:
+    """Search the web with DuckDuckGo and return up the results.
+
+    Args:
+        query: The query term to search the internet for
+        safe_search: "off" | "moderate" | "strict"
+    """
+    return searchtool.web_search(query, safe_search)
+
+
+@mcp.tool()
+async def send_msg(query: str, concise_report: str) -> str:
+    """Send a message to telegram using the original query and concise report
+
+    Args:
+        query: The query given by the user
+        concise_report: The generated report
+    """
+    return msg_agent.send_msg(query, concise_report)
+
+
+if __name__ == "__main__":
+    mcp.run(transport='stdio')

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/msg_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/msg_agent.py
@@ -1,0 +1,53 @@
+import os, socket, requests
+from agents import Agent, ModelSettings
+from base_model import ollama_model
+from dotenv import load_dotenv
+
+
+load_dotenv(override=True)
+
+telegram_bot_token = os.getenv("TELEGRAM_BOT_TOKEN")
+telegram_chat_id = os.getenv("TELEGRAM_CHAT_ID")
+telegram_url = f"https://api.telegram.org/bot{telegram_bot_token}/sendMessage"
+telegram_sync = False
+
+try:
+    print("Telegram DNS:", socket.gethostbyname_ex("api.telegram.org"))  # will raise if blocked
+    telegram_sync = True
+except:
+    print("Telegram DNS blocked")
+
+# @function_tool
+def send_msg(query: str, concise_report: str) -> str:
+    """Send a message to telegram using the original query and concise report"""
+
+    def push(message):
+        if telegram_sync:
+            print(f"Push Sync: {message}")
+            payload = {"chat_id": telegram_chat_id, "text": message}
+            response = requests.post(telegram_url, json=payload)
+            return response.json()
+        else:
+            print(f"Message not sent: {message}")
+            return {"ok": True}
+
+    r = push(f'Query: {query}\nDetails: {concise_report}')
+    print("Msg response", r)
+    return "done"
+
+
+INSTRUCTIONS = """You are able to send a short and crisp telegram message based on a detailed report.
+You will be provided with a detailed report. You should call your tool only once to request sending the message, 
+converting the report into clean, well presented, short, and crisp message. """
+
+
+def get_msg_agent(mcp_server):
+    msg_agent = Agent(
+        name="MessageAgent",
+        instructions=INSTRUCTIONS,
+        # tools=[send_msg],
+        mcp_servers=[mcp_server],
+        model=ollama_model,
+        model_settings=ModelSettings(temperature=0),
+    )
+    return msg_agent

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/planner_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/planner_agent.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, Field
+from agents import Agent
+from base_model import ollama_model
+
+HOW_MANY_SEARCHES = 1
+
+INSTRUCTIONS = (f"You are a helpful research assistant. Given a query, come up with a limited set of web searches "
+                f"(upto {HOW_MANY_SEARCHES}) to perform to best answer the query. "
+                f"Output the {HOW_MANY_SEARCHES} terms to query for.")
+
+
+class WebSearchItem(BaseModel):
+    reason: str = Field(description="Your reasoning for why this search is important to the query.")
+    query: str = Field(description="The search term to use for the web search.")
+
+
+class WebSearchPlan(BaseModel):
+    searches: list[WebSearchItem] = Field(description="A concise list of web searches to perform to best answer the query.")
+    
+planner_agent = Agent(
+    name="PlannerAgent",
+    model=ollama_model,
+    instructions=INSTRUCTIONS,
+    output_type=WebSearchPlan,
+)

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/research_manager.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/research_manager.py
@@ -1,0 +1,143 @@
+from agents import Agent, Runner, trace, set_tracing_disabled
+from main_agent import main_agent
+from eval_agent import eval_agent, EvalData
+from search_agent import get_search_agent
+from planner_agent import planner_agent, WebSearchItem, WebSearchPlan
+from writer_agent import writer_agent, ReportData
+from docker_agent import get_docker_agent
+from msg_agent import get_msg_agent
+import asyncio
+from agents.mcp import MCPServerStdio
+
+# Prevent default cloud tracing/pings
+# set_tracing_disabled(True)
+
+class ResearchManager:
+
+    async def run(self, query: str):
+        params = {"command": "python", "args": ["mcp_server.py"]}
+        with trace("mcp-proj"):
+            async with MCPServerStdio(name='MyMcpServer', params=params, client_session_timeout_seconds=1200) as mcp_server:
+                mcp_tools = await mcp_server.list_tools()
+                print('mcp tools:', mcp_tools)
+
+                """ Run the deep research process, yielding the status updates and the final report"""
+                print("Starting research...")
+                yield "Generating initial report ..."
+                report = await self.main_report(query)
+                yield "Initial report generated. Evaluating ..."
+                eval_accept = await self.eval_report(query, report.text_report)
+                if not eval_accept:
+                    yield "Evaluated and not accepted, planning searches ..."
+                    search_plan = await self.plan_searches(query)
+                    yield "Searches planned, searching ..."
+                    search_results = await self.perform_searches(search_plan, get_search_agent(mcp_server))
+                    yield "Searches complete, writing report ..."
+                    report = await self.write_report(query, search_results)
+
+                yield "Report written, timestamping ..."
+                datestamp = await self.call_docker(get_docker_agent(mcp_server))
+                text_report = report.text_report
+                if '202' in datestamp:
+                    text_report += ' This report is generated on ' + datestamp + ' .'
+
+                yield "Timestamped, sending msg ..."
+                await self.send_msg(query, text_report, get_msg_agent(mcp_server))
+                yield "Msg sent, research complete"
+                yield text_report
+
+
+    async def main_report(self, query: str) -> ReportData:
+        """ Generate the concise report for given query """
+        print("Generating initial report...")
+        result = await Runner.run(
+            main_agent,
+            f"Query: {query}",
+        )
+        return result.final_output_as(ReportData)
+
+    async def eval_report(self, query: str, report : str) -> bool:
+        """ Evaluate given report for the query """
+        print("Evaluating first report...")
+        result = await Runner.run(
+            eval_agent,
+            f"Query: {query}, Report: {report}",
+        )
+        r = result.final_output_as(EvalData)
+        return r.accept
+
+    async def plan_searches(self, query: str) -> WebSearchPlan:
+        """ Plan the searches to perform for the query """
+        print("Planning searches...")
+        result = await Runner.run(
+            planner_agent,
+            f"Query: {query}",
+        )
+        print(f"Will perform {len(result.final_output.searches)} searches")
+        return result.final_output_as(WebSearchPlan)
+
+    async def perform_searches(self, search_plan: WebSearchPlan, search_agent: Agent) -> list[str]:
+        """ Perform the searches to perform for the query """
+        print("Searching...")
+        num_completed = 0
+        tasks = [asyncio.create_task(self.search(item, search_agent)) for item in search_plan.searches]
+        results = []
+        for task in asyncio.as_completed(tasks):
+            result = await task
+            if result is not None:
+                results.append(result)
+            num_completed += 1
+            print(f"Searching... {num_completed}/{len(tasks)} completed")
+        print("Finished searching")
+        return results
+
+    async def search(self, item: WebSearchItem, search_agent: Agent) -> str | None:
+        """ Perform a search for the query """
+        input = f"Search term: {item.query}\nReason for searching: {item.reason}"
+        print(input)
+        try:
+            result = await Runner.run(
+                search_agent,
+                input,
+            )
+            return str(result.final_output)
+        except Exception:
+            return None
+
+    async def write_report(self, query: str, search_results: list[str]) -> ReportData:
+        """ Write the report for the query """
+        print("Thinking about report...")
+        input = f"Original query: {query}\nSummarized search results: {search_results}"
+        result = await Runner.run(
+            writer_agent,
+            input,
+        )
+
+        print("Finished writing report")
+        return result.final_output_as(ReportData)
+    
+    async def send_msg(self, query: str, report: str, msg_agent: Agent) -> str:
+        print("Writing msg...")
+        result = ''
+        try:
+            result = await Runner.run(
+                msg_agent,
+                f"Query: {query}, Report: {report}",
+                max_turns=1,  # <= decide+call, then synthesize
+            )
+        except Exception:
+            print('Allowing only 1 send message tool call.')
+            pass
+        print("Message sent")
+        return result
+
+    async def call_docker(self, docker_agent: Agent) -> str:
+        print("Applying Timestamp...")
+        try:
+            result = await Runner.run(docker_agent, "Call docker tool.", max_turns=2)
+            print('result:', result)
+            return result.final_output_as(str)
+        except Exception:
+            from dockertool import get_docker_resp
+            return get_docker_resp()
+

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/search_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/search_agent.py
@@ -1,0 +1,21 @@
+from agents import Agent
+from base_model import ollama_model
+
+INSTRUCTIONS = (
+    "You are a research assistant. Given a search term, you search the web for that term "
+    "using the tool provided by the MCP Server. "
+    "Capture the main points from the search results in less than 300 words. "
+    "Write succinctly, no need to have complete sentences or good grammar. "
+    "This will be consumed by someone synthesizing a report, so its vital you capture the essence. "
+)
+
+
+def get_search_agent(mcp_server) -> Agent:
+    search_agent = Agent(
+        name="SearchAgent",
+        instructions=INSTRUCTIONS,
+        model=ollama_model,
+        mcp_servers=[mcp_server],
+    )
+    print('Created Search Agent.')
+    return search_agent

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/searchtool.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/searchtool.py
@@ -1,0 +1,20 @@
+from typing import List, Dict
+from ddgs import DDGS
+
+def web_search(query: str, safe_search: str = "moderate") -> List[Dict[str, str]]:
+    """
+    Search the web with DuckDuckGo and return up the results.
+    safe_search: "off" | "moderate" | "strict"
+    """
+    max_results = 1
+    results: List[Dict[str, str]] = []
+    # ddg regions: "wt-wt" is worldwide; you can add region=... if you want localization
+    with DDGS() as ddgs:
+        for r in ddgs.text(query, safesearch=safe_search, max_results=max_results, backend="lite"):
+            results.append({
+                "title": r.get("title") or "",
+                "url": r.get("href") or r.get("url") or "",
+                "snippet": r.get("body") or r.get("snippet") or ""
+            })
+    return results
+

--- a/6_mcp/community_contributions/sach91-mcp-ollama-telegram/writer_agent.py
+++ b/6_mcp/community_contributions/sach91-mcp-ollama-telegram/writer_agent.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+from agents import Agent
+from base_model import ollama_model
+
+INSTRUCTIONS = (
+    "You are a senior researcher tasked with writing a cohesive short report for a research query. "
+    "You will be provided with the original query, and some initial research done by a research assistant.\n"
+    "You should generate a concise report and return that as your final output.\n"
+    "The final output should be in text format, and it should be concise, not lengthy or detailed. "
+    "Aim for 2 paragraphs of content, maximum 300 words."
+)
+
+
+class ReportData(BaseModel):
+    short_summary: str = Field(description="A short 2-3 sentence summary of the findings.")
+
+    text_report: str = Field(description="The final report")
+
+    follow_up_questions: list[str] = Field(description="Suggested topics to research further")
+
+
+writer_agent = Agent(
+    name="WriterAgent",
+    instructions=INSTRUCTIONS,
+    model=ollama_model,
+    output_type=ReportData,
+)


### PR DESCRIPTION
## MCP using ollama models + telegram notification + docker container

First generate a report from LLM based on past knowledge. Then an evaluator model checks if this report is sufficient (like for simple historical questions). Otherwise, for cases like the query needs recent information, evaluator model rejects the report and initiates web-search and then uses it to for generating report. This filters the need for invoking the time consuming web-search approach. The process uses calls to MCP server for managing various operations.

```mermaid
flowchart TD
    A[Initial Report]
    B[Eval Model]
    C[Plan Search]
    D[Perform Search]
    E[Summarize]
    F[Timestamp]
    G[Send Message]

    A --> B
    B -->|Fail| C
    C --> D --> E --> F --> G
    B -->|Pass| E

    %% Make Eval Model red
    style D fill:#ffcccc,stroke:#ff0000,stroke-width:2px
    style F fill:#ffcccc,stroke:#ff0000,stroke-width:2px
    style G fill:#ffcccc,stroke:#ff0000,stroke-width:2px
```
*Red Blocks support MCP server calls for providing the functionality.* 

### Some Challenges and Insights
1. Free models using ollama are also competent to perform deep research.
2. It is not easy to control tool calls using Ollama for (llama 3.2) models, need to use fail-safe exceptions to control the call count from litellm level.
3. Implemented local web-search using [DuckDuckGo](https://duckduckgo.com) free search engine.
4. Used Docker for secure python execution to get timestamp information, which is added in the response.
5. Used OpenAI Traces for accessing logs and calls.
6. Telegram Notification, Web Search and Docker call are managed through MCP server.
7. Experienced that free models can handle agentic tasks to reasonable level.
8. Amazed to see Google Gemini goofing up (see below). 


### Some situations

1. **Query for Historical Data: Who was Alan Turing** 
    Process: Evaluator accepts the initial model report, web search not needed.
    Gradio Report:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/afca7ae3-a447-4193-9056-fcfdbb5dde03" />
    Telegram Notification:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/565188d7-cac8-4842-aa74-970f635ee6f2" />

2. **Query for Recent Information: Who won Turing Award in 2025**
    Process: Evaluator rejects the initial model report, web search is performed.
    Gradio Report:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/b18c0708-6ac7-4dbb-be1f-dcc27f59282d" />
    Telegram Notification:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/3d1c81eb-724e-447b-b55f-9ce46d4f64da" />

3. It should be noted that the model knowledge cut-off date was December 2023, and the above information was only feasible due to the web-search.
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/5ac70a29-3a5e-4d28-bf5b-7cede59b9a86" />

4. Strangely, asking the same question to Google goofed Gemini, which marked the 2024 winners as of 2025. 
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/cc085dd1-fd3a-4701-82b7-d8f55a5301c1" />

    I confirmed from ACM website that our answer is correct:
    https://www.acm.org/media-center/2025/march/turing-award-2024

