### PR TITLE
Add asyncio research notes

### DIFF
--- a/guides/community_contributions/sonyaling1947_asyncio_notes.ipynb
+++ b/guides/community_contributions/sonyaling1947_asyncio_notes.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5c291475-8c7c-461c-9b12-545a887b2432",
+   "metadata": {},
+   "source": [
+    "# Async Python\n",
+    "\n",
+    "## A briefing on asynchronous python coding, essential in Agent engineering"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "538fa044",
+   "metadata": {},
+   "source": [
+    "Here is a masterful tutorial by you-know-who with exercises and comparisons.\n",
+    "\n",
+    "https://chatgpt.com/share/680648b1-b0a0-8012-8449-4f90b540886c\n",
+    "\n",
+    "This includes how to run async code from a python module.\n",
+    "\n",
+    "### And now some examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09f5662a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's define an async function\n",
+    "\n",
+    "import asyncio\n",
+    "import time\n",
+    "# This is a coroutine\n",
+    "async def do_some_work(name, secs=1):\n",
+    "    print(f\"Starting work for {name}\")\n",
+    "    await asyncio.sleep(secs)\n",
+    "    # The following line won't execute until secs later.  It block (pause) the current coroutine call.\n",
+    "    # let event loop to run other coroutines while it is waiting\n",
+    "    # However, it is not blocking the entire thread like time.sleep()\n",
+    "    print(f\"Work complete after {secs} second(s), at {time.time()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07ab3abf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What will this do?\n",
+    "\n",
+    "do_some_work('Sonya')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d681b6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OK let's try that again!\n",
+    "\n",
+    "await do_some_work('Sonya')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea867090",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What's wrong with this?\n",
+    "\n",
+    "async def do_a_lot_of_work():\n",
+    "    do_some_work('Sonya')  # without await, it just returns a coroutine object and nothing happens\n",
+    "    do_some_work('Jimmy', 2)\n",
+    "    do_some_work('Peter', 3)\n",
+    "\n",
+    "await do_a_lot_of_work()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9c75c3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Interesting warning! Let's fix it\n",
+    "async def do_a_lot_of_work():\n",
+    "    await do_some_work('Sonya')\n",
+    "    await do_some_work('Jimmy', 2)\n",
+    "    await do_some_work('Peter', 3)\n",
+    "\n",
+    "begin = time.time()\n",
+    "print(f'Overall start time: {begin}')\n",
+    "await do_a_lot_of_work()\n",
+    "print(f\"Time taken: {time.time() - begin} seconds\")\n",
+    "\n",
+    "# The output is like \n",
+    "# Overall start time: 1764789510.4008389\n",
+    "# Starting work for Sonya\n",
+    "# Work complete after 1 second(s), at 1764789511.402349\n",
+    "# Starting work for Jimmy\n",
+    "# Work complete after 2 second(s), at 1764789513.4032419\n",
+    "# Starting work for Peter\n",
+    "# Work complete after 3 second(s), at 1764789516.404661\n",
+    "# Time taken: 6.0045270919799805 seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "720cf3f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# And now let's do it in parallel\n",
+    "# It's important to recognize that this is not \"multi-threading\" in the way that you may be used to\n",
+    "# The asyncio library is running on a single thread, but it's using a loop to switch between tasks while one is waiting\n",
+    "\n",
+    "begin = time.time()\n",
+    "print(f'Overall start time: {begin}')\n",
+    "await asyncio.gather(do_some_work('Sonya'), do_some_work('Jimmy', 2), do_some_work('Peter', 3))\n",
+    "print(f\"Time taken: {time.time() - begin} seconds\")\n",
+    "# The output is like \n",
+    "# Overall start time: 1764789322.65409\n",
+    "# Starting work for Sonya\n",
+    "# Starting work for Jimmy\n",
+    "# Starting work for Peter\n",
+    "# Work complete after 1 second(s), at 1764789323.656093\n",
+    "# Work complete after 2 second(s), at 1764789324.656141\n",
+    "# Work complete after 3 second(s), at 1764789325.656134\n",
+    "# Time taken: 3.0026931762695312 seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "613f348c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare sync time.sleep() with asyncio.sleep()\n",
+    "import time\n",
+    "def sync_work_with_time_sleep(name, secs=1):\n",
+    "    print(f\"Starting work for {name}\")\n",
+    "    time.sleep(secs)\n",
+    "    print(f\"Sync Work complete after {secs} second(s), at {time.time()}\")\n",
+    "begin = time.time()\n",
+    "print(f'Overall start time: {begin}')\n",
+    "sync_work_with_time_sleep('Sonya')\n",
+    "sync_work_with_time_sleep('Jimmy', 2)\n",
+    "sync_work_with_time_sleep('Peter', 3)\n",
+    "print(f\"Time taken: {time.time() - begin} seconds\")\n",
+    "# The output is like\n",
+    "# Overall start time: 1764789604.758095\n",
+    "# Starting work for Sonya\n",
+    "# Sync Work complete after 1 second(s), at 1764789605.763951\n",
+    "# Starting work for Jimmy\n",
+    "# Sync Work complete after 2 second(s), at 1764789607.768606\n",
+    "# Starting work for Peter\n",
+    "# Sync Work complete after 3 second(s), at 1764789610.773984\n",
+    "# Time taken: 6.016453981399536 seconds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "230f85de",
+   "metadata": {},
+   "source": [
+    "### Finally - try writing a python module that calls do_a_lot_of_work_in_parallel\n",
+    "\n",
+    "See the link at the top; you'll need something like this in your module or using context manager 'with asyncio.Runner() as runner' syntax\n",
+    "\n",
+    "```python\n",
+    "if __name__ == \"__main__\":\n",
+    "    asyncio.run(do_a_lot_of_work_in_parallel())\n",
+    "```\n",
+    "or "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f306c4bf",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "if __name__ == \"__main__\":\n",
+    "    with asyncio.Runner() as runner:    \n",
+    "        runner.run(do_a_lot_of_work_in_parallel())\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba437be3",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
To summarize
- 'await asyncio.sleep(secs)' block (pause) the current coroutine call and let event loop to run other coroutines while it is waiting. However, it is not blocking the entire thread like 'time.sleep()' does.  If time.sleep() in the main thread, time.sleep() will halt the whole process flow. That is not desirable.
- If you are doing
> await do_some_work('Sonya')
    await do_some_work('Jimmy', 2)
    await do_some_work('Peter', 3)
>    
    
You would see the same result like
>sync_work_with_time_sleep('Sonya')
sync_work_with_time_sleep('Jimmy', 2)
sync_work_with_time_sleep('Peter', 3)
>

with the output of 'Starting work, Work complete' pairs because there is only one task  in the event loop and not much to yield to.

`asyncio.gather` would give more tasks in event loop and allow parallelism.  The output would be like 
> Overall start time: 1764789322.65409
Starting work for Sonya
Starting work for Jimmy
Starting work for Peter
Work complete after 1 second(s), at 1764789323.656093
Work complete after 2 second(s), at 1764789324.656141
Work complete after 3 second(s), at 1764789325.656134
Time taken: 3.0026931762695312 seconds
>

vs using sync time.sleep()  
>Overall start time: 1764789604.758095
Starting work for Sonya
Sync Work complete after 1 second(s), at 1764789605.763951
Starting work for Jimmy
Sync Work complete after 2 second(s), at 1764789607.768606
Starting work for Peter
Sync Work complete after 3 second(s), at 1764789610.773984
Time taken: 6.016453981399536 seconds
>

Also other than `asyncio.run()` to start even loop, we can use context to start even loop as the followings:
> with asyncio.Runner() as runner:    
        runner.run(do_a_lot_of_work_in_parallel())
>        