### PR TITLE
Add SendGrid inbound reply agent with agentic SDR flow

### DIFF
--- a/2_openai/community_contributions/sendgrid-reply-bot/.env.example
+++ b/2_openai/community_contributions/sendgrid-reply-bot/.env.example
@@ -1,0 +1,2 @@
+SENDGRID_API_KEY=your_sendgrid_api_key_here
+FROM_EMAIL=verified_sender@example.com

--- a/2_openai/community_contributions/sendgrid-reply-bot/README.MD
+++ b/2_openai/community_contributions/sendgrid-reply-bot/README.MD
@@ -1,0 +1,59 @@
+# SendGrid Reply Bot (Agentic SDR Loop)
+
+This project extends the Week 2 Agentic Framework lab by adding **inbound email reply handling** using SendGrid Inbound Parse and an autonomous Agent.
+
+## What this adds
+
+- Sends a cold outbound sales email using multiple drafting agents
+- Receives user replies via SendGrid webhook
+- Uses an Agent to reason over the inbound message
+- Sends a contextual reply automatically
+- Maintains conversation continuity via email (no chat UI)
+
+## Architecture
+
+SendGrid (Inbound Parse)
+→ FastAPI webhook
+→ Agent (OpenAI Agents SDK)
+→ SendGrid outbound email
+
+## Setup
+
+1. Install dependencies
+```bash
+pip install -r requirements.txt
+
+2. Configure environment variables
+
+Create a .env file from the example template:
+cp .env.example .env
+
+Then update it with your SendGrid credentials:
+
+SENDGRID_API_KEY=your_sendgrid_api_key
+FROM_EMAIL=your_verified_sender@example.com
+
+3. Run the webhook server
+
+Start the FastAPI server locally:
+
+python -m uvicorn reply_webhook:app --port 8000
+The server will be available at:
+
+http://127.0.0.1:8000
+
+4. Expose the webhook using ngrok
+
+Since SendGrid cannot reach localhost, expose the server publicly:
+
+ngrok http 8000
+
+Copy the generated HTTPS URL and configure SendGrid Inbound Parse to point to:
+
+https://<ngrok-url>/webhooks/sendgrid/reply
+
+
+```markdown
+> Note: ngrok must be running while testing inbound replies.
+> If the tunnel URL changes, update the SendGrid Inbound Parse configuration.
+

--- a/2_openai/community_contributions/sendgrid-reply-bot/phase1_agent_email.py
+++ b/2_openai/community_contributions/sendgrid-reply-bot/phase1_agent_email.py
@@ -1,0 +1,170 @@
+import os
+import asyncio
+import uuid
+from dotenv import load_dotenv
+
+import sendgrid
+from sendgrid.helpers.mail import Mail, Email, To, Content
+
+from agents import Agent, Runner, trace, function_tool
+
+# =================================================
+# Environment
+# =================================================
+
+load_dotenv(override=True)
+
+SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
+FROM_EMAIL = os.getenv("FROM_EMAIL")
+TO_EMAIL = "dev.urvashicodes@gmail.com"  # test inbox
+
+if not SENDGRID_API_KEY or not FROM_EMAIL:
+    raise RuntimeError("Missing SENDGRID_API_KEY or FROM_EMAIL in .env")
+
+sg = sendgrid.SendGridAPIClient(api_key=SENDGRID_API_KEY)
+
+# =================================================
+# TOOL: Send Email (ONLY SIDE EFFECT)
+# =================================================
+
+@function_tool
+def send_email(email_body: str, reply_to_address: str):
+    """
+    Sends exactly ONE email with a Reply-To address.
+    """
+    mail = Mail(
+        from_email=Email(FROM_EMAIL),
+        to_emails=To(TO_EMAIL),
+        subject="ComplAI — quick intro",
+        plain_text_content=Content("text/plain", email_body),
+    )
+
+    # Critical: Reply-To for inbound parsing
+    mail.reply_to = Email(reply_to_address)
+
+    sg.client.mail.send.post(request_body=mail.get())
+    return {"status": "sent"}
+
+# =================================================
+# Drafting Agents (NO SIDE EFFECTS)
+# =================================================
+
+professional_agent = Agent(
+    name="Professional Sales Agent",
+    instructions=(
+        "You are a professional sales agent for ComplAI, "
+        "a SaaS platform that helps companies achieve SOC2 compliance. "
+        "Write a serious, polished cold email."
+    ),
+    model="gpt-4o-mini",
+)
+
+engaging_agent = Agent(
+    name="Engaging Sales Agent",
+    instructions=(
+        "You are a witty, engaging sales agent for ComplAI. "
+        "Write a friendly, conversational cold email that feels human."
+    ),
+    model="gpt-4o-mini",
+)
+
+busy_agent = Agent(
+    name="Busy Sales Agent",
+    instructions=(
+        "You are a very busy sales agent for ComplAI. "
+        "Write a short, direct cold email with minimal fluff."
+    ),
+    model="gpt-4o-mini",
+)
+
+# Convert drafting agents into tools
+professional_draft = professional_agent.as_tool(
+    "professional_draft",
+    "Generate a professional cold sales email",
+)
+
+engaging_draft = engaging_agent.as_tool(
+    "engaging_draft",
+    "Generate a witty, engaging cold sales email",
+)
+
+busy_draft = busy_agent.as_tool(
+    "busy_draft",
+    "Generate a short, direct cold sales email",
+)
+
+# =================================================
+# Email Sender Agent (ONLY ONE ALLOWED TO SEND)
+# =================================================
+
+email_sender = Agent(
+    name="Email Sender",
+    instructions="""
+You receive:
+- email_body
+- reply_to_address
+
+Your job:
+- Send EXACTLY ONE email using the send_email tool
+- Use the provided reply_to_address unchanged
+- Do not rewrite the email body
+""",
+    tools=[send_email],
+    model="gpt-4o-mini",
+)
+
+# =================================================
+# Sales Manager (THINKS + DECIDES + HANDOFF)
+# =================================================
+
+sales_manager = Agent(
+    name="Sales Manager",
+    instructions="""
+You are a Sales Manager at ComplAI.
+
+Steps:
+1. Use ALL THREE draft tools to generate email drafts.
+2. Compare them carefully.
+3. Choose the single best email.
+4. Hand off ONE payload containing:
+   - email_body (the selected draft)
+   - reply_to_address (provided by the user)
+
+Rules:
+- You must NOT write emails yourself.
+- You must NOT send emails yourself.
+- You must hand off EXACTLY ONE payload.
+""",
+    tools=[professional_draft, engaging_draft, busy_draft],
+    handoffs=[email_sender],
+    model="gpt-4o-mini",
+)
+
+# =================================================
+# MAIN
+# =================================================
+
+async def main():
+    # Unique lead identifier
+    lead_id = f"lead_{uuid.uuid4().hex[:8]}"
+
+    # MUST match SendGrid Inbound Parse host
+    reply_to_address = f"{lead_id}@replies.urvashipatel.io"
+
+    # Explicit payload so agents can pass it through cleanly
+    message = f"""
+Write a cold sales email addressed to Dear CEO.
+
+Reply-To Address (IMPORTANT — pass through unchanged):
+{reply_to_address}
+"""
+
+    with trace("Phase 1 — Agent Selection + Send"):
+        await Runner.run(sales_manager, message)
+
+    print("✅ Phase 1 complete")
+    print("Lead ID:", lead_id)
+    print("Reply-To:", reply_to_address)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/2_openai/community_contributions/sendgrid-reply-bot/reply_webhook.py
+++ b/2_openai/community_contributions/sendgrid-reply-bot/reply_webhook.py
@@ -1,0 +1,88 @@
+import os
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request
+
+import sendgrid
+from sendgrid.helpers.mail import Mail, Email, To, Content
+
+from agents import Agent, Runner, function_tool
+
+# ----------------------------------
+# Setup
+# ----------------------------------
+
+load_dotenv(override=True)
+
+SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
+FROM_EMAIL = os.getenv("FROM_EMAIL")
+
+sg = sendgrid.SendGridAPIClient(api_key=SENDGRID_API_KEY)
+
+app = FastAPI()
+
+# ----------------------------------
+# Tool: send reply email (side effect)
+# ----------------------------------
+
+@function_tool
+def send_reply(to_email: str, subject: str, body: str):
+    """Send a single reply email to the prospect."""
+    mail = Mail(
+        from_email=Email(FROM_EMAIL),
+        to_emails=To(to_email),
+        subject=subject,
+        plain_text_content=Content("text/plain", body),
+    )
+    sg.client.mail.send.post(request_body=mail.get())
+    return {"status": "reply_sent"}
+
+# ----------------------------------
+# SDR Reply Agent
+# ----------------------------------
+
+reply_agent = Agent(
+    name="SDR Reply Agent",
+    instructions="""
+You are an SDR continuing a sales conversation.
+
+Rules:
+- Respond naturally to what the prospect wrote
+- Ask ONE follow-up question
+- If the prospect says they are not interested, politely disengage
+- Keep replies under 120 words
+""",
+    tools=[send_reply],
+    model="gpt-4o-mini",
+)
+
+# ----------------------------------
+# Webhook endpoint
+# ----------------------------------
+
+@app.post("/webhooks/sendgrid/reply")
+async def receive_reply(request: Request):
+    form = await request.form()
+
+    prospect_email = form.get("from")
+    original_subject = form.get("subject", "Re: ComplAI — quick intro")
+    message_text = form.get("text")
+
+    await Runner.run(
+        reply_agent,
+        input=f"""
+Inbound reply received.
+
+Prospect email:
+{prospect_email}
+
+Original subject:
+{original_subject}
+
+Message:
+{message_text}
+
+Write a concise, helpful reply and send it using the send_reply tool.
+"""
+    )
+
+    return {"status": "ok"}

--- a/2_openai/community_contributions/sendgrid-reply-bot/requirements.txt
+++ b/2_openai/community_contributions/sendgrid-reply-bot/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+python-dotenv
+sendgrid
+openai
+openai-agents
+python-multipart


### PR DESCRIPTION
This contribution adds a working example of an agentic SDR reply flow using SendGrid inbound webhooks.

Features:
- Phase 1 outbound email sent via agent selection
- Dynamic reply-to addresses per lead
- FastAPI webhook to receive SendGrid inbound replies
- SDR reply agent that responds contextually and sends a follow-up email
- Clean separation between side effects (email) and agent reasoning

This example demonstrates a realistic end-to-end agent workflow:
outbound → inbound → agent reasoning → reply.

Happy to adjust structure or naming if needed.
