### PR TITLE
Openai lab 2 - this time with only the changes I intended to include in the PR!

### DIFF
--- a/2_openai/community_contributions/eliza_zadura/SETUP.md
+++ b/2_openai/community_contributions/eliza_zadura/SETUP.md
@@ -1,0 +1,108 @@
+# Mailjet Reply Webhook - Setup Guide
+
+## Prerequisites
+
+- Python virtual environment with dependencies installed
+- Mailjet account with API keys configured
+- ngrok installed (https://ngrok.com/download)
+
+## Step 1: Start the Webhook Server
+
+Open a terminal and run:
+
+```bash
+cd c:\Dev\Learning\ai_engineer_agentic_track\agents_mine\agents
+.venv\Scripts\uvicorn.exe 2_openai.community_contributions.eliza_zadura.reply_webhook:app --port 8000
+```
+
+Verify it's running by visiting: http://127.0.0.1:8000/
+
+You should see:
+```json
+{"status":"running","service":"Mailjet Reply Webhook"}
+```
+
+## Step 2: Expose via ngrok
+
+Open another terminal and run:
+
+```bash
+ngrok http 8000
+```
+
+Copy the HTTPS forwarding URL (e.g., `https://abc123.ngrok-free.app`)
+
+> **Note:** The ngrok URL changes each time you restart it (unless you have a paid plan with reserved domains).
+
+## Step 3: Configure Mailjet Parse API
+
+1. Log in to Mailjet: https://app.mailjet.com/
+
+2. Navigate to **Transactional** → **Inbound** → **Parse Routes**
+
+3. Click **Create a Parse Route**:
+   - **Email address:** Create or choose a parseable address (e.g., `reply@parse.yourdomain.com`)
+   - **Webhook URL:** Paste your ngrok URL + `/webhook/reply`
+     - Example: `https://abc123.ngrok-free.app/webhook/reply`
+
+4. Save the Parse Route
+
+## Step 4: Configure Domain MX Records
+
+For Mailjet to receive emails on your domain, you need to set up MX records:
+
+1. In Mailjet, go to **Account Settings** → **Sender Domains & Addresses**
+
+2. Add your domain and follow Mailjet's DNS configuration instructions
+
+3. Add the MX record to your domain's DNS:
+   - **Type:** MX
+   - **Host:** `parse` (or your chosen subdomain)
+   - **Value:** `parse.mailjet.com`
+   - **Priority:** 10
+
+4. Wait for DNS propagation (can take up to 48 hours, usually faster)
+
+## Step 5: Test the Integration
+
+1. Send an email TO the parse address you configured (e.g., `reply@parse.yourdomain.com`)
+
+2. Mailjet will POST the email data to your webhook
+
+3. The AI agent will craft a response and send it back via Mailjet
+
+4. Check your inbox for the AI-generated reply!
+
+## Troubleshooting
+
+### Webhook not receiving requests
+- Ensure ngrok is running and the URL is correct in Mailjet
+- Check the ngrok web interface at http://127.0.0.1:4040 to see incoming requests
+
+### Emails not sending
+- Verify your Mailjet API keys are correct in `.env`
+- Check that the sender email is verified in Mailjet
+
+### Server errors
+- Check the terminal running uvicorn for error messages
+- Ensure all dependencies are installed: `pip install fastapi uvicorn mailjet-rest openai-agents`
+
+## Architecture
+
+```
+Prospect replies to email
+        ↓
+    Mailjet receives email
+        ↓
+    Mailjet Parse API POSTs to ngrok
+        ↓
+    ngrok forwards to localhost:8000
+        ↓
+    FastAPI /webhook/reply endpoint
+        ↓
+    SDR Reply Agent (GPT-4o-mini)
+        ↓
+    send_reply tool → Mailjet API
+        ↓
+    Prospect receives AI response
+```

--- a/2_openai/community_contributions/eliza_zadura/reply_webhook.py
+++ b/2_openai/community_contributions/eliza_zadura/reply_webhook.py
@@ -1,0 +1,139 @@
+"""
+Mailjet Reply Webhook Server
+
+A FastAPI server that receives inbound email replies via Mailjet's Parse API
+and uses an AI agent to generate and send contextual responses.
+
+Usage:
+    # Terminal 1: Start the webhook server
+    uvicorn reply_webhook:app --port 8000
+
+    # Terminal 2: Expose via ngrok
+    ngrok http 8000
+
+Then configure Mailjet Parse Route to POST to: https://<ngrok-url>/webhook/reply
+"""
+
+import os
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request
+from mailjet_rest import Client
+from agents import Agent, Runner, function_tool
+
+# ----------------------------------
+# Setup
+# ----------------------------------
+
+load_dotenv(override=True)
+
+MAILJET_API_KEY = os.environ.get("MAILJET_API_KEY")  # Your Mailjet keys
+MAILJET_SECRET_KEY = os.environ.get("MAILJET_SECRET_KEY")
+FROM_EMAIL = os.environ.get("FROM_EMAIL")
+FROM_NAME = os.environ.get("FROM_NAME")
+
+app = FastAPI()
+
+
+# ----------------------------------
+# Tool: send reply email
+# ----------------------------------
+
+
+@function_tool
+def send_reply(to_email: str, to_name: str, subject: str, body: str):
+    """Send a reply email to the prospect."""
+    mailjet = Client(
+        auth=(MAILJET_API_KEY, MAILJET_SECRET_KEY),
+        version="v3.1",
+    )
+    data = {
+        "Messages": [
+            {
+                "From": {"Email": FROM_EMAIL, "Name": FROM_NAME},
+                "To": [{"Email": to_email, "Name": to_name}],
+                "Subject": subject,
+                "TextPart": body,
+            }
+        ]
+    }
+    response = mailjet.send.create(data=data)
+    return {"status": "reply_sent", "status_code": response.status_code}
+
+
+# ----------------------------------
+# SDR Reply Agent
+# ----------------------------------
+
+reply_agent = Agent(
+    name="SDR Reply Agent",
+    instructions="""
+You are an SDR (Sales Development Representative) continuing a sales conversation
+for ComplAI, an AI-powered SaaS tool for SOC2 compliance.
+
+Rules:
+- Respond naturally to what the prospect wrote
+- Ask ONE follow-up question to keep the conversation going
+- If the prospect says they are not interested, politely thank them and disengage
+- Keep replies under 120 words
+- Be professional but friendly
+- Always use the send_reply tool to send your response
+""",
+    tools=[send_reply],
+    model="gpt-4o-mini",
+)
+
+
+# ----------------------------------
+# Webhook endpoint
+# ----------------------------------
+
+
+@app.post("/webhook/reply")
+async def receive_reply(request: Request):
+    """
+    Receives inbound email data from Mailjet Parse API.
+    
+    Mailjet sends form data with fields like:
+    - From: sender email
+    - Subject: email subject
+    - Text-part: plain text body
+    - Html-part: HTML body (if available)
+    """
+    form = await request.form()
+
+    # Extract email details from Mailjet's Parse API payload
+    prospect_email = form.get("From", "unknown@example.com")
+    prospect_name = form.get("From", "Prospect").split("<")[0].strip()
+    subject = form.get("Subject", "Re: ComplAI")
+    message_text = form.get("Text-part", "") or form.get("Html-part", "")
+
+    # Run the agent to craft and send a response
+    await Runner.run(
+        reply_agent,
+        input=f"""
+Inbound reply received from a sales prospect.
+
+Prospect email: {prospect_email}
+Prospect name: {prospect_name}
+Subject: {subject}
+
+Their message:
+{message_text}
+
+Craft a helpful, concise reply and send it using the send_reply tool.
+Use "Re: {subject}" as the subject line.
+"""
+    )
+
+    return {"status": "ok"}
+
+
+# ----------------------------------
+# Health check endpoint
+# ----------------------------------
+
+
+@app.get("/")
+async def health_check():
+    """Simple health check endpoint."""
+    return {"status": "running", "service": "Mailjet Reply Webhook"}

--- a/2_openai/community_contributions/eliza_zadura/reply_webhook_plan.md
+++ b/2_openai/community_contributions/eliza_zadura/reply_webhook_plan.md
@@ -1,0 +1,88 @@
+---
+name: Mailjet Reply Webhook
+overview: Create a FastAPI webhook server that receives inbound email replies via Mailjet's Parse API and uses an AI agent to generate and send contextual responses.
+todos:
+  - id: create-webhook
+    content: Create reply_webhook.py with FastAPI app, Mailjet send_reply tool, and SDR Reply Agent
+    status: completed
+  - id: test-local
+    content: Test locally by running uvicorn and sending a manual POST request
+    status: completed
+  - id: setup-ngrok
+    content: Run ngrok and note the public URL
+    status: completed
+  - id: configure-mailjet
+    content: Set up Mailjet Parse Route pointing to ngrok URL (manual step with instructions)
+    status: completed
+---
+
+# Mailjet Reply Webhook Implementation
+
+## Why a Separate Python File (Not Notebook)
+
+A webhook server needs to:
+- Run continuously waiting for incoming HTTP requests
+- Be exposable via ngrok to the internet
+- Be started with `uvicorn` or similar ASGI server
+
+Notebooks are designed for interactive, cell-by-cell execution — not for long-running servers. A `.py` file is the right choice here.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Prospect
+    participant Mailjet
+    participant ngrok
+    participant FastAPI
+    participant Agent
+    
+    Prospect->>Mailjet: Replies to sales email
+    Mailjet->>ngrok: POST parsed email data
+    ngrok->>FastAPI: Forward to /webhook/reply
+    FastAPI->>Agent: Process reply with context
+    Agent->>Mailjet: Send response via API
+    Mailjet->>Prospect: Delivers AI response
+```
+
+## Implementation
+
+### 1. Create `reply_webhook.py`
+
+A new file in `2_openai/` containing:
+
+- **FastAPI app** with a single POST endpoint `/webhook/reply`
+- **`send_reply` tool** using Mailjet (matching your existing pattern)
+- **SDR Reply Agent** that reads the inbound message and crafts a response
+- Endpoint parses Mailjet's Parse API payload and triggers the agent
+
+### 2. Mailjet Parse API Setup (Manual Steps)
+
+You'll need to:
+1. Set up a subdomain for receiving emails (e.g., `parse.yourdomain.com`)
+2. Configure MX records to point to Mailjet
+3. Create a Parse Route in Mailjet pointing to your ngrok URL
+
+### 3. Running the Server
+
+```bash
+# Terminal 1: Start the webhook server
+uvicorn reply_webhook:app --port 8000
+
+# Terminal 2: Expose via ngrok
+ngrok http 8000
+```
+
+Then configure Mailjet Parse Route to use the ngrok HTTPS URL.
+
+## Key Differences from the Notebook Code
+
+| Aspect | Notebook | Webhook Server |
+|--------|----------|----------------|
+| Execution | Cell-by-cell | Continuous server |
+| Email direction | Outbound only | Inbound + Outbound |
+| Trigger | You run a cell | HTTP POST from Mailjet |
+
+## Files to Create
+
+- `2_openai/reply_webhook.py` — the webhook server (~60 lines)


### PR DESCRIPTION


Add Mailjet Reply Webhook for Automated SDR Responses
Implements the hard challenge from Lab 2: an agentic email reply loop using Mailjet's Parse API.
What it does:

    FastAPI webhook receives inbound email replies via Mailjet Parse API
    An AI agent (GPT-4o-mini) crafts contextual responses to prospect messages
    Replies are sent automatically via Mailjet, continuing the sales conversation

Files added:

reply_webhook.py — webhook server with SDR Reply Agent
reply_webhook_plan.md — implementation plan
SETUP.md — setup guide for ngrok + Mailjet Parse API configuration

Tech stack:

FastAPI + uvicorn
Mailjet (Parse API for inbound, Send API for outbound)
OpenAI Agents SDK
ngrok for local development

P.S. (it is totally the wrong place for it, but I forgot!) Agentic patterns used - parallelization (3 sales agents with asyncio.gather()). Orchestrator-worker, the sales manager orchestrates worker agents, delegating writing emails. Evaluator-optimizer, the sales manager.

And...the line that changed it to 'Agent': when tools are passed to sales_manager = Agent (..., tools=tools, ...)
