### PR TITLE
Add FastAPI endpoint for stock picker

### DIFF
--- a/3_crew/community_contributions/latest_market_research/src/latest_market_research/app.py
+++ b/3_crew/community_contributions/latest_market_research/src/latest_market_research/app.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from latest_market_research.crew import LatestMarketResearch
+
+app = FastAPI(title="Stock Picker API")
+
+# ------------------------------
+# Pydantic model for user input
+# ------------------------------
+class StockPickerInput(BaseModel):
+    topic: str
+    risk_profile: str
+    investment_horizon: str
+    region: str
+    market_cap_preference: str
+    number_of_picks: int  # cast to int directly
+
+
+# ------------------------------
+# Health check / root endpoint
+# ------------------------------
+@app.get("/")
+def read_root():
+    return {"message": "Stock Picker API is running!"}
+
+
+# ------------------------------
+# Main stock picker endpoint
+# ------------------------------
+@app.post("/stock-picker")
+def stock_picker_endpoint(inputs: StockPickerInput):
+    """
+    Receives user inputs, runs the stock picker, and returns results.
+    """
+    # Convert Pydantic model to dict
+    input_dict = inputs.dict()
+
+    # Run the crew
+    crew_instance = LatestMarketResearch()
+    result = crew_instance.crew().kickoff(inputs=input_dict)
+
+    # Return JSON
+    return {"results": result.raw}

--- a/3_crew/community_contributions/latest_market_research/src/latest_market_research/config/agents.yaml
+++ b/3_crew/community_contributions/latest_market_research/src/latest_market_research/config/agents.yaml
@@ -1,0 +1,57 @@
+emerging_companies_finder:
+  role: >
+    Senior {topic} Market Researcher
+  goal: >
+    You read the latest news, then find about 5 companies that are trending in the news for further research.
+    Focus on companies operating primarily in the {region} region and aligned with
+    {market_cap_preference}-cap preferences. Conduct in-depth research to identify emerging companies, market trends, and investment opportunities within {topic}.
+    Prioritize the latest, most relevant information from reliable sources.Always pick new companies.
+    Do not pick the same company twice.
+  backstory: >
+    You are a senior market researcher expert in {topic} with years of experience analyzing {topic} industries.
+    Your expertise lies in uncovering emerging companies,
+    evaluating market potential, and extracting insights from the most recent news and data.
+    You know how to filter out irrelevant or outdated information and focus only on what is actionable and evidence-based.
+    When analyzing companies, you consider market position, growth potential, innovation, competitive landscape, and risks.
+    Your research is concise, structured, and ready to be passed to analysts for detailed reporting.
+    Output should be professional, structured, and easy to understand for decision-makers.
+    You spot multiple companies that are trending in the news and you are able to pick the best ones for further research.
+  llm: openai/gpt-4o-mini
+
+
+financial_researcher:
+  role: >
+    {topic} Senior Financial Researcher
+  goal: >
+    Given details of the companies, provide a comprehensive financial and strategic analysis
+    tailored to a {risk_profile} risk profile and a {investment_horizon} investment horizon.
+  backstory: >
+    You are an expert financial expert researcher with a proven track record of deeply analyzing hot
+     {topic} companies and building comprehensive reports.
+  llm: openai/gpt-4o-mini
+
+
+
+stock_picker:
+  role: >
+    Stock Picker from Research
+  goal: >
+    Given a list of researched companies with investment potential, you select the best (number_of_picks)
+     companies for investment  based on the user's {risk_profile} and {investment_horizon}.
+     Don't pick the same company twice. Clearly justify selections and exclusions.
+  backstory: >
+    You are a meticulous, skilled financial analyst with a proven track record of equity selection.
+    You have a talent for synthesizing research and picking the best companies for investment.
+  llm: openai/gpt-4o-mini
+
+
+manager:
+  role: >
+    Research Manager
+  goal: >
+    You are a skilled project manager who can delegate tasks in order to achieve your goal,
+     which is to pick the best five(5) companies for investment.
+  backstory: >
+    You are an experienced and highly effective project manager who can delegate tasks to the right people.
+  llm: openai/gpt-4o-mini
+

--- a/3_crew/community_contributions/latest_market_research/src/latest_market_research/config/tasks.yaml
+++ b/3_crew/community_contributions/latest_market_research/src/latest_market_research/config/tasks.yaml
@@ -1,0 +1,33 @@
+find_emerging_companies:
+  description: >
+    Find the top emerging companies in the {topic} sector,
+    focusing on the {region} region and aligned with {market_cap_preference}-cap preferences.
+  expected_output: >
+    A list of emerging companies in the {topic} sector with brief explanations for why they are trending.
+  agent: emerging_companies_finder
+  output_file: output/emerging_companies.json
+
+research_emerging_companies:
+  description: >
+    Given a list of emerging companies, provide detailed analysis of each company in a report by searching online.
+  expected_output: >
+    A report containing detailed analysis of each emerging company.
+  agent: financial_researcher
+  context:
+    - find_emerging_companies
+  output_file: output/emerging_companies_research.json
+
+
+pick_best_companies:
+  description: >
+    Given a list of emerging companies with investment potential, 
+    select the best {number_of_picks} companies for investment
+    based on the user's risk profile and investment horizon.
+    Don't pick the same company twice. 
+    Notify the user with a 1-sentence rationale for the final selection.
+  expected_output: >
+    The chosen companies and why they were chosen; the companies that were not selected and why they were not selected.
+  agent: stock_picker
+  context:
+    - research_emerging_companies
+  output_file: output/decision.md

--- a/3_crew/community_contributions/latest_market_research/src/latest_market_research/crew.py
+++ b/3_crew/community_contributions/latest_market_research/src/latest_market_research/crew.py
@@ -1,0 +1,145 @@
+from multiprocessing import process
+from tabnanny import verbose
+from crewai import Agent, Crew, Process, Task
+from crewai.project import CrewBase, agent, crew, task
+from crewai.agents.agent_builder.base_agent import BaseAgent
+from typing import List
+from pydantic import BaseModel , Field
+from crewai_tools import SerperDevTool
+from crewai.memory import LongTermMemory,ShortTermMemory, EntityMemory
+from crewai.memory.storage.rag_storage import RAGStorage
+from crewai.memory.storage.llm_sqlite_storage import LTMSQLiteStorage
+
+
+##Setting up structured outputs###
+
+class EmergingCompany(BaseModel):
+    """ A company that is in the news and attracting attention"""
+
+    name: str = Field(description="Company name")
+    ticker: str = Field(description="Stock ticker symnol")
+    reason: str = Field(description="Reason this company is trending in the news")
+
+
+class EmergingCompanyList(BaseModel):
+    """List of multiple emerging companies that are in the news"""
+    companies: List[EmergingCompany] = Field(description="List of companies emerging and trending in the news")
+
+
+class EmergingCompaniesResearch(BaseModel):
+    """Detailed research on a company"""
+    name: str = Field(description="Company name")
+    market_positon: str = Field(description="Current market position and competitive analysis")
+    future_outlook : str = Field(description="Future outlook and growth prospect")
+    investment_potential : str = Field(description="Investment potential and suitability for investment")
+
+
+class EmergingCompaniesResearchList(BaseModel):
+    """List of detailed research on the companies"""
+    research_List: List[EmergingCompaniesResearch] = Field(description="Comprehensive research on all trending companies")
+
+
+
+@CrewBase
+class LatestMarketResearch():
+    """LatestMarketResearch crew"""
+
+    agents_config = 'config/agents.yaml'
+    tasks_config = 'config/tasks.yaml'
+
+##Setting up all agents###
+    @agent
+    def emerging_companies_finder(self)-> Agent:
+        return Agent(config=self.agents_config['emerging_companies_finder'], tools=[SerperDevTool()], memory=True)
+
+    @agent
+    def financial_researcher(self)-> Agent:
+        return Agent(config=self.agents_config['financial_researcher'], tools=[SerperDevTool()])
+
+    @agent
+    def stock_picker(self) -> Agent:
+        return Agent(config=self.agents_config['stock_picker'], memory=True)
+
+
+
+
+
+##Setting up all tasks###
+    @task
+    def find_emerging_companies(self) -> Task:
+        return Task(config=self.tasks_config['find_emerging_companies'], output_pydantic=EmergingCompanyList)
+    
+    @task
+    def research_emerging_companies(self) -> Task:
+        return Task(config=self.tasks_config['research_emerging_companies'],output_pydantic=EmergingCompaniesResearchList)
+
+    @task
+    def best_company_picker(self) -> Task:
+        return Task(config=self.tasks_config['pick_best_companies'])
+
+
+
+##Setting up the crew###
+
+
+
+    @crew
+    def crew(self) -> Crew:
+        """Creates the stockpicker crew"""
+
+        manager = Agent(
+            config=self.agents_config['manager'],
+            allow_delegation=True
+        )
+
+        short_term_memory = ShortTermMemory(
+
+            storage = RAGStorage(
+                embedder_config={
+                    "provider": "openai",
+                    "config": {
+                        "model": 'text-embedding-3-small'
+                    }
+                },
+                type="short_term",
+                path="./memory/"
+            )
+        )
+
+        long_term_memory = LongTermMemory(
+            storage=LTMSQLiteStorage(
+                db_path="./memory/long_term_memory_storage.db"
+            )
+        )
+
+        entity_memory = EntityMemory(
+            storage=RAGStorage(
+                embedder_config={
+                    "provider":"openai",
+                    "config":{
+                        "model":'text-embedding-3-small'
+                    }
+                },
+                type="short_term",
+                path="./memory/"
+            )
+        )
+
+
+
+        return Crew(
+            agents=self.agents,
+            tasks=self.tasks,
+            process=Process.hierarchical,
+            verbose=True,
+            manager_agent=manager,
+            memory = True,
+            short_term_memory = short_term_memory,
+            long_term_memory=long_term_memory,
+            entity_memory = entity_memory            
+            
+            
+            )
+    
+
+

--- a/3_crew/community_contributions/latest_market_research/src/latest_market_research/main.py
+++ b/3_crew/community_contributions/latest_market_research/src/latest_market_research/main.py
@@ -1,0 +1,34 @@
+import warnings
+
+from datetime import datetime
+
+from latest_market_research.crew import LatestMarketResearch
+
+warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
+
+
+def run():
+    """
+    Run the crew.
+    """
+    inputs = {
+        'topic': 'Technology',
+        'risk_profile': 'High',
+        'investment_horizon':'Short',
+        'region': 'Europe',
+        'market_cap_preference':'any',
+        'number_of_picks':'3'
+    }
+
+    #Create and run the crew
+
+    result = LatestMarketResearch().crew().kickoff(inputs=inputs)
+
+
+    #Print the result
+    print("\n\n===Final Decision ===\n\n")
+    print(result.raw)
+
+
+if __name__=="__main__":
+    run()

--- a/3_crew/community_contributions/latest_market_research/src/streamlit_app.py
+++ b/3_crew/community_contributions/latest_market_research/src/streamlit_app.py
@@ -1,0 +1,35 @@
+import streamlit as st
+from latest_market_research.crew import LatestMarketResearch
+
+st.set_page_config(page_title="Stock Picker", page_icon="📈")
+
+st.title("Stock Picker")
+
+# Input fields
+topic = st.text_input("Topic", "Technology")
+risk_profile = st.selectbox("Risk Profile", ["Low", "Medium", "High"])
+investment_horizon = st.selectbox("Investment Horizon", ["Short", "Medium", "Long"])
+region = st.text_input("Region", "Europe")
+market_cap_preference = st.selectbox("Market Cap Preference", ["Any", "Large", "Mid", "Small"])
+number_of_picks = st.number_input("Number of Picks", min_value=1, max_value=10, value=3, step=1)
+
+# Run button
+if st.button("Pick Stocks"):
+    input_dict = {
+        "topic": topic,
+        "risk_profile": risk_profile,
+        "investment_horizon": investment_horizon,
+        "region": region,
+        "market_cap_preference": market_cap_preference,
+        "number_of_picks": number_of_picks,
+    }
+
+    st.info("Running the Stock Picker...")
+
+    try:
+        crew_instance = LatestMarketResearch()
+        result = crew_instance.crew().kickoff(inputs=input_dict)
+        st.success("Done!")
+        st.json(result.raw)
+    except Exception as e:
+        st.error(f"Error: {e}")


### PR DESCRIPTION
Hi Ed,

Please find this PR for merge. This introduces FastAPI integration for the stock picker workflow, with the following features:

1. New /stock-picker POST endpoint: Exposes the crew workflow as a callable API.
2. User Input Handling: Accepts a JSON payload containing parameters such as topic, risk_profile, investment_horizon, region, market_cap_preference, and number_of_picks.
3. Output: Returns the results from crew().kickoff() as JSON, enabling programmatic access to stock picker decisions.
4. Verified Functionality: Successfully tested in the terminal to ensure correct processing of inputs and output generation.
5. Modular Design: The FastAPI wrapper is separated from the core crew logic, making it easy to integrate with web frontends, dashboards, or other applications in the future.

This PR lays the groundwork for production-ready API access to the stock picker and allows front-end developers to interact with the workflow without modifying the core logic.

Thank you.