### PR TITLE
Fix writing files to the sandbox in 6_mcp/1_lab1.ipynb

### DIFF
--- a/6_mcp/1_lab1.ipynb
+++ b/6_mcp/1_lab1.ipynb
@@ -169,6 +169,7 @@
     "appropriate to get to the content you need. If one website isn't fruitful, try another. \n",
     "Be persistent until you have solved your assignment,\n",
     "trying different options and sites as needed.\n",
+    "When you need to write files, you do that inside the sandbox folder only.\n",
     "\"\"\"\n",
     "\n",
     "\n",


### PR DESCRIPTION
## 🔥 Warning 🔥
The change in this pr is not inside the community_contributions, and that's on purpose to fix a small glitch in the main project.

## Context
I noticed a tool error on attempting to write files by the LLM in week `6_mcp/1_lab1.ipynb`, which is due to the fact that the LLM was just trying to write a file in the root of the current folder instead of the allowed sandbox folder.

## Fix
In this PR I append a little statement to the agent instructions to make sure that any attempt of writing files will happen inside the sandbox folder.

## Further steps
Since the main branch already has a `banoffee.md` file committed, it's possible that students could run the agent and not notice that the file was not rewritten. So we could either
- delete the committed `banoffee.md` (but then we will have to add a .keep file inside the sandbox folder to keep the structure), or
- just empty the `banoffee.md` from its content, so students can notice how the recipe gets filled when the agent succeeds or it stays empty when it doesn't.

## Reference 

| Before | After |
|--------|--------|
| <img width="1273" height="468" alt="before" src="https://github.com/user-attachments/assets/8f974994-e1ed-4f86-b27d-f76ce69ad3c3" /> | <img width="1265" height="394" alt="after" src="https://github.com/user-attachments/assets/6c3ab794-06bc-44df-af0e-63720f9ff3fe" /> | 