### PR TITLE
chore: broaden .gitignore to stop committing runtime DB artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,19 @@ memory.db
 # Ignore Accounts database in capstone project
 6_mcp/accounts.db
 6_mcp/memory/*.db
+
+# Databases and vector store artifacts (ChromaDB, SQLite, etc.)
+# These files are runtime-generated and should not be committed.
+*.sqlite3
+*.sqlite
+*.db
+*.db-shm
+*.db-wal
+chroma.sqlite3
+data_level0.bin
+header.bin
+length.bin
+link_lists.bin
+
+# Generated audio/media artifacts from agent runs
+*.wav


### PR DESCRIPTION
First, a big thank you to Ed for **The Complete Agentic AI Engineering Course (2025)**. I learned a lot from it. I already built my own agents, and I am still working through the material. I also plan to check out the other courses on your list next, because the way you explain things (clear, practical, and hands-on) really works for me. Thanks for putting this together.

With that said, here is a small contribution back. When I first cloned the repo, it was noticeably slow. I looked into why, and found a lot of runtime-generated files adding to the size. That is what motivated this PR.

## Problem

Cloning the repo pulls down ~97 MB of git data (working tree ~211 MB). A big chunk of that comes from runtime-generated database and binary files that contributors committed over time:

- **ChromaDB vector stores**: `chroma.sqlite3`, `data_level0.bin`, `header.bin`, `length.bin`, `link_lists.bin`
- **SQLite runtime databases**: `*.db`, `*.db-wal`, `*.db-shm`, `*.sqlite`
- **Generated audio**: `*.wav`

The existing `.gitignore` only matched a narrow set of exact names (`memory.db`, `memory.db-wal`, `memory.db-shm`, `6_mcp/accounts.db`, `6_mcp/memory/*.db`), so contributors kept committing their local runtime state without realizing it.

## Changes

This PR is intentionally **non-destructive**:

- **Broaden `.gitignore`** to catch the patterns above going forward.
- **Leave already-tracked files alone.** No `git rm --cached`, no file deletions. Existing forks, clones, and open PRs stay unaffected. Nothing disappears from anyone's working tree on pull.

**Effect:** New contributions stop adding DB/vector-store artifacts. The repo stops growing from this class of mistake.

## Why not also untrack existing files?

A `git rm --cached` sweep would:

- Delete the files from every contributor's working tree on their next pull (potentially wiping locally-populated Chroma stores and agent memory).
- Break open PRs and forks that touch any of these paths with merge conflicts.
- Still not shrink clone size (blobs remain in history).

Given that the course has a large contributor base with active forks, the right sequencing is:

1. **This PR**: Stop the bleeding via `.gitignore` (safe, no one notices).
2. **Future, coordinated PR**: Selectively untrack the most egregious tracked artifacts (e.g. the ~8 MB ChromaDB folders), announced in advance so contributors can save local state.
3. **Optional, far-future**: History rewrite (`git filter-repo` / BFG) to actually shrink clones. This is disruptive for all forks and needs coordination.

## Test plan

- [x] `.gitignore` patterns verified against representative tracked paths (`3_crew/stock_picker/memory/chroma.sqlite3`, `4_langgraph/memory.db`, `*.wav` under `NLP_Agent_Dinesh_Uthayakumar`).
- [x] `git status` on a clean checkout shows no unintended deletions.
- [ ] Confirm CI still passes. No code paths change.