### PR TITLE
Added a Remote MCP server proxy example and Dockerization

### DIFF
--- a/6_mcp/community_contributions/Carbaz/Remote mcp-proxy example/Dockerfile
+++ b/6_mcp/community_contributions/Carbaz/Remote mcp-proxy example/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim
+
+# Install uv (includes uvx)
+RUN pip install uv
+
+# Default command
+CMD ["uvx", "mcp-proxy", "--port=8000", "--host=0.0.0.0", "uvx", "mcp-server-fetch"]

--- a/6_mcp/community_contributions/Carbaz/Remote mcp-proxy example/proxy_fetch_demo.ipynb
+++ b/6_mcp/community_contributions/Carbaz/Remote mcp-proxy example/proxy_fetch_demo.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3068126d",
+   "metadata": {},
+   "source": [
+    "# Serve an STDIO MCP server over SSE with mcp-proxy\n",
+    "\n",
+    "This notebook demonstrates how to expose an MCP server that communicates over STDIO (for example, `mcp-server-fetch`) as an MCP SSE endpoint using `mcp-proxy`.\n",
+    "\n",
+    "[`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) wraps any STDIO-based MCP server and exposes it as a proper MCP SSE transport endpoint, allowing clients to connect with `MCPServerSse` from the OpenAI Agents SDK  \n",
+    "instead of spawning a local STDIO subprocess per client. This makes it easy for multiple notebooks or agents to share a single server instance.\n",
+    "\n",
+    "This lets multiple notebooks or agents connect to the same server concurrently.\n",
+    "\n",
+    "What you'll learn\n",
+    "- Start `mcp-proxy` to wrap `mcp-server-fetch` and expose `/sse`.\n",
+    "- Connect from this notebook using `MCPServerSse` (OpenAI Agents SDK) and list available tools.\n",
+    "- Stop the proxy cleanly and manage the server process.\n",
+    "- Run `mcp-proxy` inside Docker as an alternative deployment.\n",
+    "\n",
+    "Key advantages\n",
+    "- SSE uses standard HTTP connections, so the MCP server can run on a remote host and be reached over the network via its SSE endpoint.\n",
+    "- Server starts once and can be consumed by multiple notebooks/agents simultaneously.\n",
+    "- Clean async communication: MCP over SSE instead of multiple STDIO subprocesses.\n",
+    "\n",
+    "Architecture\n",
+    "```\n",
+    "Notebook  ──MCPServerSse──►  mcp-proxy (:8000/sse)  ──stdio──►  mcp-server-fetch\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b477a180",
+   "metadata": {},
+   "source": [
+    "## Standalone server (local mcp-proxy)\n",
+    "\n",
+    "In this section we will run `mcp-proxy` locally to wrap `mcp-server-fetch`, verify the SSE endpoint is reachable,  \n",
+    "connect from this notebook using `MCPServerSse` to list available tools, and finally stop the proxy process.\n",
+    "\n",
+    "Notes:\n",
+    "\n",
+    "- Default port used in this notebook: `8000`.\n",
+    "- On Windows the launch command uses `cmd /c` and process control uses `PowerShell`.\n",
+    "- If the port is already in use, change the `MCP_PROXY_PORT` constant in the code below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "952b15bd",
+   "metadata": {},
+   "source": [
+    "### 1. Start mcp-proxy (wrap `mcp-server-fetch`)\n",
+    "\n",
+    "`mcp-proxy` launches `mcp-server-fetch` via STDIO and exposes it as an MCP SSE endpoint.\n",
+    "\n",
+    "CLI (for reference):\n",
+    "\n",
+    "```bash\n",
+    "uvx mcp-proxy --port 8000 uvx mcp-server-fetch\n",
+    "```\n",
+    "\n",
+    "The SSE endpoint will be: `http://localhost:8000/sse`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "53caab01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set params and commands based on the OS.\n",
+    "import sys\n",
+    "\n",
+    "MCP_PROXY_PORT = 8000\n",
+    "\n",
+    "# MCP Proxy launch command, uses the 'cmd /c' prefix version on Windows.\n",
+    "if sys.platform == 'win32':\n",
+    "    MCP_PROXY_CMD = f\"cmd /c uvx mcp-proxy --port={MCP_PROXY_PORT} uvx mcp-server-fetch\"\n",
+    "    GET_PID_CMD = f\"powershell -Command Get-NetTCPConnection -LocalPort {MCP_PROXY_PORT} | Select-Object -ExpandProperty OwningProcess\"\n",
+    "    KILL_PID_CMD = \"powershell -Command Stop-Process -Id {} -Force\"\n",
+    "else:  # Assume Unix-like. (Linux, macOS)\n",
+    "    MCP_PROXY_CMD = f\"uvx mcp-proxy --port={MCP_PROXY_PORT} uvx mcp-server-fetch\"\n",
+    "    GET_PID_CMD = f\"lsof -i :{MCP_PROXY_PORT} -t\"\n",
+    "    KILL_PID_CMD = \"kill -9 {}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "b1e1478a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mcp-proxy SSE endpoint: http://localhost:8000/sse\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Launch SSE to STDIO Proxy.\n",
+    "import subprocess\n",
+    "\n",
+    "proxy_proc = subprocess.Popen(MCP_PROXY_CMD)\n",
+    "\n",
+    "MCP_PROXY_SSE_URL = f\"http://localhost:{MCP_PROXY_PORT}/sse\"\n",
+    "print(f\"mcp-proxy SSE endpoint: {MCP_PROXY_SSE_URL}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "849f2509",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for mcp-proxy  ✓ ready\n",
+      "42524\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Wait for the port to be open (socket check avoids hanging on the SSE stream)\n",
+    "import time\n",
+    "import socket\n",
+    "\n",
+    "print(\"Waiting for mcp-proxy \", end='')\n",
+    "for _ in range(5):\n",
+    "    try:\n",
+    "        with socket.create_connection((\"localhost\", MCP_PROXY_PORT), timeout=1):\n",
+    "            print(\" ✓ ready\")\n",
+    "            break\n",
+    "    except OSError:\n",
+    "        print(f\".\", end='')\n",
+    "        time.sleep(0.5)\n",
+    "else:\n",
+    "    print(\" ✗ failed to start\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f5dbdd9",
+   "metadata": {},
+   "source": [
+    "### 2. Connect with `MCPServerSse` and list tools\n",
+    "\n",
+    "Use `MCPServerSse` (OpenAI Agents SDK) to connect to the running MCP SSE endpoint and list the available tools.  \n",
+    "Functionally identical to `MCPServerStdio`, but using MCP over SSE instead of STDIO subprocesses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "1b8b551e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Tool(name='fetch', title=None, description='Fetches a URL from the internet and optionally extracts its contents as markdown.\\n\\nAlthough originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.', inputSchema={'description': 'Parameters for fetching a URL.', 'properties': {'url': {'description': 'URL to fetch', 'format': 'uri', 'minLength': 1, 'title': 'Url', 'type': 'string'}, 'max_length': {'default': 5000, 'description': 'Maximum number of characters to return.', 'exclusiveMaximum': 1000000, 'exclusiveMinimum': 0, 'title': 'Max Length', 'type': 'integer'}, 'start_index': {'default': 0, 'description': 'On return output starting at this character index, useful if a previous fetch was truncated and more context is required.', 'minimum': 0, 'title': 'Start Index', 'type': 'integer'}, 'raw': {'default': False, 'description': 'Get the actual HTML content of the requested page, without simplification.', 'title': 'Raw', 'type': 'boolean'}}, 'required': ['url'], 'title': 'Fetch', 'type': 'object'}, outputSchema=None, icons=None, annotations=None, meta=None)]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now we can connect to the MCP proxy server using the MCPServerSse client.\n",
+    "from agents.mcp import MCPServerSse\n",
+    "\n",
+    "async with MCPServerSse(params={\"url\": MCP_PROXY_SSE_URL}, client_session_timeout_seconds=60) as server:\n",
+    "    fetch_tools = await server.list_tools()\n",
+    "\n",
+    "fetch_tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94a89d7e",
+   "metadata": {},
+   "source": [
+    "### 3. Stop the proxy\n",
+    "\n",
+    "Find the real server PID and terminate the MCP proxy process. The code cell below locates the server PID and stops it (Windows: PowerShell `Stop-Process`; Unix: `kill`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "451786e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CompletedProcess(args='powershell -Command Stop-Process -Id 41636 -Force', returncode=0)"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Kill the server process on the real PID\n",
+    "\n",
+    "# mcp-proxy process launched a detached server so we need to find the real PID\n",
+    "server_pid = subprocess.run(GET_PID_CMD, capture_output=True, text=True).stdout.strip()\n",
+    "subprocess.run(KILL_PID_CMD.format(server_pid))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d7634e5",
+   "metadata": {},
+   "source": [
+    "## Docker (recommended)\n",
+    "\n",
+    "Run `mcp-proxy` inside a container to avoid host process management and ensure a reproducible, isolated runtime.  \n",
+    "The container exposes the MCP SSE endpoint on a mapped host port so clients connect to `/sse` without launching local STDIO servers.\n",
+    "\n",
+    "Benefits\n",
+    "- Isolated runtime and easy cleanup (start/stop containers instead of managing PIDs).\n",
+    "- Reproducible image across machines and CI.\n",
+    "- Simple port mapping to expose `/sse`.\n",
+    "- Easy to deploy and scale in a microservices architecture: agents on different hosts can share the same containerized service.\n",
+    "- More secure: container isolation reduces risk and makes it safer to run potentially dangerous tools (e.g., a REPL) inside the service.\n",
+    "- If the MCP server maintains shared state or \"memory\", that state is available to all agents connecting to the same endpoint.\n",
+    "\n",
+    "Use the following cells to build the demo image, run the container (example: host 8001 → container 8000), connect with `MCPServerSse`, and stop the container."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2e0333a",
+   "metadata": {},
+   "source": [
+    "### 1. Build Docker image\n",
+    "\n",
+    "Build the demo image from the Dockerfile (next code cell runs `docker build`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "d3a86a5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CompletedProcess(args='docker build -t mcp-proxy-demo .', returncode=0)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "image_name = \"mcp-proxy-demo\"\n",
+    "subprocess.run(f\"docker build -t {image_name} .\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44bd20e2",
+   "metadata": {},
+   "source": [
+    "### 2. Launch container\n",
+    "\n",
+    "Start the `mcp-proxy-demo` container and map a host port (example: host 8001 → container 8000)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "51f65dc0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CompletedProcess(args='docker run -d --rm --name mcp-proxy-demo -p 8001:8000 mcp-proxy-demo', returncode=0)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "MCP_DOCKER_PORT = 8001\n",
+    "MCP_DOCKER_SSE_URL = f\"http://localhost:{MCP_DOCKER_PORT}/sse\"\n",
+    "\n",
+    "subprocess.run(f\"docker run -d --rm --name mcp-proxy-demo -p {MCP_DOCKER_PORT}:8000 mcp-proxy-demo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "48345b50",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for mcp-proxy  ✓ ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Wait for the port to be open (socket check avoids hanging on the SSE stream)\n",
+    "import time\n",
+    "import socket\n",
+    "\n",
+    "print(\"Waiting for mcp-proxy \", end='')\n",
+    "for _ in range(5):\n",
+    "    try:\n",
+    "        with socket.create_connection((\"localhost\", MCP_DOCKER_PORT), timeout=1):\n",
+    "            print(\" ✓ ready\")\n",
+    "            break\n",
+    "    except OSError:\n",
+    "        print(f\".\", end='')\n",
+    "        time.sleep(0.5)\n",
+    "else:\n",
+    "    print(\" ✗ failed to start\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0baf443b",
+   "metadata": {},
+   "source": [
+    "### 3. Connect with `MCPServerSse` (Docker)\n",
+    "\n",
+    "Connect to the containerized SSE endpoint (`MCP_DOCKER_SSE_URL`) and list available tools. This mirrors the local flow but targets the container host and port."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "bd02ebcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Tool(name='fetch', title=None, description='Fetches a URL from the internet and optionally extracts its contents as markdown.\\n\\nAlthough originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.', inputSchema={'description': 'Parameters for fetching a URL.', 'properties': {'url': {'description': 'URL to fetch', 'format': 'uri', 'minLength': 1, 'title': 'Url', 'type': 'string'}, 'max_length': {'default': 5000, 'description': 'Maximum number of characters to return.', 'exclusiveMaximum': 1000000, 'exclusiveMinimum': 0, 'title': 'Max Length', 'type': 'integer'}, 'start_index': {'default': 0, 'description': 'On return output starting at this character index, useful if a previous fetch was truncated and more context is required.', 'minimum': 0, 'title': 'Start Index', 'type': 'integer'}, 'raw': {'default': False, 'description': 'Get the actual HTML content of the requested page, without simplification.', 'title': 'Raw', 'type': 'boolean'}}, 'required': ['url'], 'title': 'Fetch', 'type': 'object'}, outputSchema=None, icons=None, annotations=None, meta=None)]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now we can connect to the MCP proxy server using the MCPServerSse client.\n",
+    "from agents.mcp import MCPServerSse\n",
+    "\n",
+    "async with MCPServerSse(params={\"url\": MCP_DOCKER_SSE_URL}, client_session_timeout_seconds=60) as server:\n",
+    "    fetch_tools = await server.list_tools()\n",
+    "\n",
+    "fetch_tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17992553",
+   "metadata": {},
+   "source": [
+    "### 4. Stop server container\n",
+    "\n",
+    "Stop and remove the `mcp-proxy-demo` container (example: `docker stop mcp-proxy-demo`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "be793bc6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CompletedProcess(args='docker stop mcp-proxy-demo', returncode=0)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Stop the Docker container for the MCP proxy demo server\n",
+    "import subprocess\n",
+    "\n",
+    "subprocess.run(\"docker stop mcp-proxy-demo\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "agents (3.13.13)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/6_mcp/community_contributions/Carbaz/Remote mcp-proxy example/proxy_fetch_demo.ipynb
+++ b/6_mcp/community_contributions/Carbaz/Remote mcp-proxy example/proxy_fetch_demo.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "53caab01",
    "metadata": {},
    "outputs": [],
@@ -91,18 +91,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "id": "b1e1478a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "mcp-proxy SSE endpoint: http://localhost:8000/sse\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Launch SSE to STDIO Proxy.\n",
     "import subprocess\n",
@@ -115,19 +107,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "849f2509",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for mcp-proxy  ✓ ready\n",
-      "42524\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Wait for the port to be open (socket check avoids hanging on the SSE stream)\n",
     "import time\n",
@@ -159,21 +142,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "1b8b551e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Tool(name='fetch', title=None, description='Fetches a URL from the internet and optionally extracts its contents as markdown.\\n\\nAlthough originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.', inputSchema={'description': 'Parameters for fetching a URL.', 'properties': {'url': {'description': 'URL to fetch', 'format': 'uri', 'minLength': 1, 'title': 'Url', 'type': 'string'}, 'max_length': {'default': 5000, 'description': 'Maximum number of characters to return.', 'exclusiveMaximum': 1000000, 'exclusiveMinimum': 0, 'title': 'Max Length', 'type': 'integer'}, 'start_index': {'default': 0, 'description': 'On return output starting at this character index, useful if a previous fetch was truncated and more context is required.', 'minimum': 0, 'title': 'Start Index', 'type': 'integer'}, 'raw': {'default': False, 'description': 'Get the actual HTML content of the requested page, without simplification.', 'title': 'Raw', 'type': 'boolean'}}, 'required': ['url'], 'title': 'Fetch', 'type': 'object'}, outputSchema=None, icons=None, annotations=None, meta=None)]"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now we can connect to the MCP proxy server using the MCPServerSse client.\n",
     "from agents.mcp import MCPServerSse\n",
@@ -196,21 +168,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "id": "451786e6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CompletedProcess(args='powershell -Command Stop-Process -Id 41636 -Force', returncode=0)"
-      ]
-     },
-     "execution_count": 56,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Kill the server process on the real PID\n",
     "\n",
@@ -252,21 +213,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "d3a86a5c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CompletedProcess(args='docker build -t mcp-proxy-demo .', returncode=0)"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import subprocess\n",
     "\n",
@@ -286,21 +236,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "51f65dc0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CompletedProcess(args='docker run -d --rm --name mcp-proxy-demo -p 8001:8000 mcp-proxy-demo', returncode=0)"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import subprocess\n",
     "\n",
@@ -312,18 +251,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "48345b50",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Waiting for mcp-proxy  ✓ ready\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Wait for the port to be open (socket check avoids hanging on the SSE stream)\n",
     "import time\n",
@@ -354,21 +285,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "bd02ebcc",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Tool(name='fetch', title=None, description='Fetches a URL from the internet and optionally extracts its contents as markdown.\\n\\nAlthough originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.', inputSchema={'description': 'Parameters for fetching a URL.', 'properties': {'url': {'description': 'URL to fetch', 'format': 'uri', 'minLength': 1, 'title': 'Url', 'type': 'string'}, 'max_length': {'default': 5000, 'description': 'Maximum number of characters to return.', 'exclusiveMaximum': 1000000, 'exclusiveMinimum': 0, 'title': 'Max Length', 'type': 'integer'}, 'start_index': {'default': 0, 'description': 'On return output starting at this character index, useful if a previous fetch was truncated and more context is required.', 'minimum': 0, 'title': 'Start Index', 'type': 'integer'}, 'raw': {'default': False, 'description': 'Get the actual HTML content of the requested page, without simplification.', 'title': 'Raw', 'type': 'boolean'}}, 'required': ['url'], 'title': 'Fetch', 'type': 'object'}, outputSchema=None, icons=None, annotations=None, meta=None)]"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now we can connect to the MCP proxy server using the MCPServerSse client.\n",
     "from agents.mcp import MCPServerSse\n",
@@ -391,21 +311,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "be793bc6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CompletedProcess(args='docker stop mcp-proxy-demo', returncode=0)"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Stop the Docker container for the MCP proxy demo server\n",
     "import subprocess\n",


### PR DESCRIPTION
This PR adds a Jupyter notebook and a Dockerfile that demonstrate how to expose a STDIO-based MCP server as a remote SSE endpoint and connect to it from Python code, covering a scenario not addressed by existing material: shared, remotely reachable MCP servers.

The demo uses `mcp-proxy` to wrap `mcp-server-fetch` (a STDIO-only server) and expose it over SSE, so any number of clients can connect to the same running instance via a standard HTTP endpoint.

The notebook walks through two deployment modes, running `mcp-proxy` directly on the host and running it inside a Docker container, then connects to each using `MCPServerSse` from the OpenAI Agents SDK and lists the available tools.

The Dockerfile packages the whole thing into a single portable image that can be deployed on any OS, machine, or cloud environment, and started and stopped without managing detached processes or PIDs.

Beyond the demo itself, this opens up a practical architectural pattern: In a multi-agent system, instead of each agent spawning its own local MCP subprocess, they can all connect to a single shared MCP service.

This distributes access, avoids duplicating server state, and in cases where the MCP server maintains memory or context, ensures all agents in the system see the same state. 

Deploying via Docker also adds a layer of isolation that makes it safer to expose potentially risky tooling (such as a REPL) inside the service boundary.

The code handles Windows and Unix (Linux/macOS) differences for the local flow. Docker is cross-platform by nature. 

> [!NOTE]
> Everything has been verified on Windows.
>
> Feedback from Linux/macOS users on the local flow would be welcome.

---

**What the notebook teaches**
* How to launch `mcp-proxy` wrapping a STDIO MCP server and expose it as an SSE endpoint.
* How to verify the endpoint is reachable before connecting.
* How to connect from Python using `MCPServerSse` (OpenAI Agents SDK) and list available tools.
* How to stop the proxy cleanly (local PID lookup and kill, both Windows and Unix).
* How to build and run the same setup inside Docker, connect to the containerized endpoint, and stop the container.

**Direct benefits**
* Wrap any STDIO server, from a public repo, a package, or built yourself, and it becomes a **Remote MCP SSE server**.
* Single shared MCP server instance across multiple agents, with shared state and load distribution.
* No per-agent STDIO subprocesses; clients connect over HTTP to the SSE endpoint.
* Docker deployment: reproducible, isolated, easier to operate than detached local processes.
* Network-transparent: the SSE endpoint can be on a remote host, enabling true microservices architectures.
* Safer runtime for sensitive tools (such as a REPL) thanks to container isolation.

**Files added**
* `proxy_fetch_demo.ipynb`: Step-by-step notebook covering the full local and Docker demo flows.
* `Dockerfile`: Minimal image that installs `uv`/`uvx` and runs `mcp-proxy` wrapping `mcp-server-fetch`, on internal port 8000.