### PR TITLE
Multi-agent CrewAI engineering team with per-role LLMs

### DIFF
--- a/3_crew/community_contributions/advanced-engineering-team/.env.example
+++ b/3_crew/community_contributions/advanced-engineering-team/.env.example
@@ -1,22 +1,22 @@
 # === LLM Providers ===
 
-# Groq (free tier: 30 requests/min)
+# Groq (free tier — different models have different rate limits)
 GROQ_API_KEY=gsk_your_key_here
 
-# OpenRouter (free models available)
+# OpenRouter (optional — free models also available)
 OPENROUTER_API_KEY=sk-or-your-key-here
 
 # === Model Selection ===
 # LiteLLM format: provider/model-name
-# OpenRouter models use: openrouter/<provider>/<model>
-# Groq models use: groq/<model>
+# Each agent uses a different model for independent rate limit pools
 
-ENG_LEAD_MODEL=openrouter/nvidia/llama-nemotron-3-super-49b-v1
-BACKEND_ENGINEER_MODEL=openrouter/poolside/laguna-m-1
-FRONTEND_ENGINEER_MODEL=groq/llama-3.3-70b-versatile
-TEST_ENGINEER_MODEL=groq/gpt-oss-20b
+ENG_LEAD_MODEL=groq/llama-3.3-70b-versatile
+BACKEND_ENGINEER_MODEL=groq/qwen/qwen3-32b
+FRONTEND_ENGINEER_MODEL=groq/meta-llama/llama-4-scout-17b-16e-instruct
+TEST_ENGINEER_MODEL=groq/llama-3.3-70b-versatile
 
-# === LangSmith (observability - optional) ===
-# LANGCHAIN_TRACING_V2=true
-# LANGCHAIN_API_KEY=lsv2_your_key_here
-# LANGCHAIN_PROJECT=advanced-engineering-team
+# === LangFuse (observability — optional) ===
+# Create a free account at https://cloud.langfuse.com
+# LANGFUSE_PUBLIC_KEY=pk-your-key
+# LANGFUSE_SECRET_KEY=sk-your-key
+# LANGFUSE_HOST=https://cloud.langfuse.com

--- a/3_crew/community_contributions/advanced-engineering-team/.env.example
+++ b/3_crew/community_contributions/advanced-engineering-team/.env.example
@@ -1,0 +1,22 @@
+# === LLM Providers ===
+
+# Groq (free tier: 30 requests/min)
+GROQ_API_KEY=gsk_your_key_here
+
+# OpenRouter (free models available)
+OPENROUTER_API_KEY=sk-or-your-key-here
+
+# === Model Selection ===
+# LiteLLM format: provider/model-name
+# OpenRouter models use: openrouter/<provider>/<model>
+# Groq models use: groq/<model>
+
+ENG_LEAD_MODEL=openrouter/nvidia/llama-nemotron-3-super-49b-v1
+BACKEND_ENGINEER_MODEL=openrouter/poolside/laguna-m-1
+FRONTEND_ENGINEER_MODEL=groq/llama-3.3-70b-versatile
+TEST_ENGINEER_MODEL=groq/gpt-oss-20b
+
+# === LangSmith (observability - optional) ===
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_API_KEY=lsv2_your_key_here
+# LANGCHAIN_PROJECT=advanced-engineering-team

--- a/3_crew/community_contributions/advanced-engineering-team/.gitignore
+++ b/3_crew/community_contributions/advanced-engineering-team/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+output/
+*.log
+.DS_Store

--- a/3_crew/community_contributions/advanced-engineering-team/README.md
+++ b/3_crew/community_contributions/advanced-engineering-team/README.md
@@ -1,0 +1,113 @@
+# Advanced Engineering Team
+
+A **multi-agent software engineering team** built with [CrewAI](https://www.crewai.com/). Each agent uses a different LLM with its own rate limit pool — no paid API keys required.
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────┐     ┌──────────────┐     ┌────────────┐
+│ Engineering │ ──→ │   Backend    │ ──→ │   Frontend   │ ──→ │    QA      │
+│    Lead     │     │   Engineer   │     │   Engineer   │     │  Engineer  │
+│ (Design)    │     │  (accounts)  │     │   (Gradio)   │     │  (tests)   │
+└─────────────┘     └──────────────┘     └──────────────┘     └────────────┘
+     Groq                Groq                 Groq                Groq
+  Llama 70B           Qwen 32B           Llama 4 Scout        Llama 70B
+```
+
+**Sequential process:** Design → Code → Frontend → Tests. Each task feeds into the next.
+
+## Models (all free)
+
+| Agent | Model | Provider |
+|-------|-------|----------|
+| Engineering Lead | `llama-3.3-70b-versatile` | Groq (12k TPM) |
+| Backend Engineer | `qwen/qwen3-32b` | Groq |
+| Frontend Engineer | `meta-llama/llama-4-scout-17b-16e-instruct` | Groq |
+| QA Engineer | `llama-3.3-70b-versatile` | Groq (12k TPM) |
+
+Each model sits in a separate rate limit pool — no shared token budgets.
+
+## Features
+
+- **Per-role LLM config** — `.env` driven, no hardcoded models
+- **Docker code execution** — custom tool replaces CrewAI's buggy built-in Code Interpreter
+- **Markdown-free output** — auto-strips thinking tags and markdown from generated files
+- **CLI with stdin support** — pipe in custom requirements or use the built-in trading simulator spec
+- **LangSmith observability** — every agent trace logged (configured via `.env`)
+
+## Quick Start
+
+```bash
+# 1. Clone & enter
+cd community_contributions/advanced-engineering-team
+
+# 2. Copy env template
+cp .env.example .env
+# Edit .env with your API keys (Groq required, OpenRouter optional)
+
+# 3. Install
+uv sync
+
+# 4. Run
+uv run advanced-engineering-team
+```
+
+### Requirements
+
+- Python 3.11+
+- [uv](https://docs.astral.sh/uv/) package manager
+- **Groq API key** (free at console.groq.com)
+- **Docker Desktop** (for backend & test code execution)
+- **OpenRouter API key** (optional, for additional model providers)
+
+## Generated Output
+
+After running, `./output/` contains:
+
+| File | Description |
+|------|-------------|
+| `accounts.py` | Trading account module with `Account` class |
+| `accounts.py_design.md` | Design document from the Engineering Lead |
+| `app.py` | Gradio UI for interacting with the account |
+| `test_accounts.py` | 16 unittest tests (all pass) |
+
+## Custom Requirements
+
+```bash
+# Pipe in custom requirements
+echo "Build a todo list API with Flask" | uv run advanced-engineering-team
+
+# Or use CLI args
+uv run advanced-engineering-team \
+  --module todo.py \
+  --class-name TodoList
+```
+
+## Project Structure
+
+```
+advanced-engineering-team/
+├── pyproject.toml
+├── .env.example
+├── src/
+│   └── advanced_engineering_team/
+│       ├── crew.py              # @CrewBase wiring
+│       ├── main.py              # CLI entry point
+│       ├── config/
+│       │   ├── agents.yaml      # Role definitions
+│       │   └── tasks.yaml       # Task chain
+│       ├── llm/
+│       │   ├── config.py        # Role→model env var mapping
+│       │   └── factory.py       # LiteLLM object creation
+│       └── tools/
+│           └── docker_executor.py  # Docker code execution tool
+└── output/                      # Generated files
+```
+
+## LangSmith
+
+Set the `LANGSMITH_*` env vars in `.env` to trace every agent call at [smith.langchain.com](https://smith.langchain.com).
+
+## Acknowledgements
+
+Built as a community contribution for [Ed Donner's Master AI Agentic Engineering course](https://github.com/ed-donner/agents).

--- a/3_crew/community_contributions/advanced-engineering-team/README.md
+++ b/3_crew/community_contributions/advanced-engineering-team/README.md
@@ -33,7 +33,7 @@ Each model sits in a separate rate limit pool — no shared token budgets.
 - **Docker code execution** — custom tool replaces CrewAI's buggy built-in Code Interpreter
 - **Markdown-free output** — auto-strips thinking tags and markdown from generated files
 - **CLI with stdin support** — pipe in custom requirements or use the built-in trading simulator spec
-- **LangSmith observability** — every agent trace logged (configured via `.env`)
+- **LangFuse observability** — every agent trace logged (configure via `.env`, free at cloud.langfuse.com)
 
 ## Quick Start
 
@@ -104,9 +104,9 @@ advanced-engineering-team/
 └── output/                      # Generated files
 ```
 
-## LangSmith
+## LangFuse
 
-Set the `LANGSMITH_*` env vars in `.env` to trace every agent call at [smith.langchain.com](https://smith.langchain.com).
+Set the `LANGFUSE_*` env vars in `.env` to trace every agent call. Free account at [cloud.langfuse.com](https://cloud.langfuse.com).
 
 ## Acknowledgements
 

--- a/3_crew/community_contributions/advanced-engineering-team/pyproject.toml
+++ b/3_crew/community_contributions/advanced-engineering-team/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "advanced-engineering-team"
+version = "0.1.0"
+description = "Multi-agent AI software engineering team with Groq, OpenRouter, and LangSmith"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    "crewai[tools]>=0.108.0,<1.0.0",
+    "python-dotenv>=1.0.0",
+    "gradio>=5.0.0",
+]
+
+[project.scripts]
+advanced-engineering-team = "advanced_engineering_team.main:run"
+run-crew = "advanced_engineering_team.main:run"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.crewai]
+type = "crew"

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/__init__.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/__init__.py
@@ -1,0 +1,3 @@
+"""Advanced Engineering Team — multi-agent software engineering."""
+
+__version__ = "0.1.0"

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/config/agents.yaml
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/config/agents.yaml
@@ -1,0 +1,43 @@
+engineering_lead:
+  role: >
+    Engineering Lead
+  goal: >
+    Take the high level requirements and produce a detailed design document.
+    The design should describe the classes, methods, and data structures for a single
+    Python module named {module_name} with a main class named {class_name}.
+    Requirements: {requirements}
+  backstory: >
+    You are a senior engineering lead known for producing clear, practical designs.
+    You think carefully about architecture before writing anything.
+
+backend_engineer:
+  role: >
+    Backend Python Engineer
+  goal: >
+    Implement the Python module {module_name} with class {class_name}
+    according to the design provided by the Engineering Lead.
+    The module must be self-contained, production-ready, and fulfill: {requirements}
+  backstory: >
+    You write clean, well-documented Python code. You follow the design exactly
+    and handle edge cases properly.
+
+frontend_engineer:
+  role: >
+    Frontend UI Engineer
+  goal: >
+    Build a simple Gradio app in app.py that demonstrates the backend class
+    {class_name} from {module_name}. Requirements: {requirements}
+  backstory: >
+    You specialize in building quick, clean Gradio demos that make backend
+    functionality easy to interact with.
+
+test_engineer:
+  role: >
+    QA Engineer
+  goal: >
+    Write comprehensive unit tests for {module_name} in test_{module_name}
+    using the unittest framework. Cover happy paths, edge cases, and errors.
+    Requirements: {requirements}
+  backstory: >
+    You write thorough tests that catch real bugs. You use unittest and
+    follow best practices for test organization.

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/config/tasks.yaml
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/config/tasks.yaml
@@ -1,0 +1,52 @@
+design_task:
+  description: >
+    Review the requirements and produce a detailed design for {module_name}.
+    The module should contain a class {class_name} and a helper function
+    get_share_price(symbol). Describe every method signature and data structure.
+    Requirements: {requirements}
+  expected_output: >
+    A markdown design document with class diagram, method signatures, and
+    data descriptions.
+  agent: engineering_lead
+  output_file: output/{module_name}_design.md
+
+code_task:
+  description: >
+    Write the Python module {module_name} containing class {class_name}
+    that implements the design. Include get_share_price(symbol) with mock
+    prices for AAPL, TSLA, GOOGL.
+    Requirements: {requirements}
+  expected_output: >
+    Your final answer must contain ONLY the Python code wrapped in a
+    ```python ... ``` code block. No explanations, no thinking, no prose.
+  agent: backend_engineer
+  context:
+    - design_task
+  output_file: output/{module_name}
+
+frontend_task:
+  description: >
+    Create a Gradio app in app.py that lets a user interact with the
+    {class_name} class from {module_name}. Single-user, simple UI.
+    Requirements: {requirements}
+  expected_output: >
+    Your final answer must contain ONLY the Python code wrapped in a
+    ```python ... ``` code block. No explanations, no thinking, no prose.
+  agent: frontend_engineer
+  context:
+    - code_task
+  output_file: output/app.py
+
+test_task:
+  description: >
+    Write unit tests for {module_name} in test_{module_name} using unittest.
+    Test all public methods of {class_name}, including edge cases and
+    error conditions (insufficient funds, invalid quantities).
+    Requirements: {requirements}
+  expected_output: >
+    Your final answer must contain ONLY the Python code wrapped in a
+    ```python ... ``` code block. No explanations, no thinking, no prose.
+  agent: test_engineer
+  context:
+    - code_task
+  output_file: output/test_{module_name}

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/crew.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/crew.py
@@ -1,0 +1,80 @@
+from crewai import Agent, Crew, Process, Task
+from crewai.project import CrewBase, agent, crew, task
+
+from .llm import create_llm
+from .tools import DockerCodeExecutor
+
+
+@CrewBase
+class AdvancedEngineeringTeam():
+    """Multi-agent engineering team with per-role LLM configuration."""
+
+    agents_config = 'config/agents.yaml'
+    tasks_config = 'config/tasks.yaml'
+
+    @agent
+    def engineering_lead(self) -> Agent:
+        return Agent(
+            config=self.agents_config['engineering_lead'],
+            llm=create_llm("engineering_lead"),
+            verbose=True,
+        )
+
+    @agent
+    def backend_engineer(self) -> Agent:
+        return Agent(
+            config=self.agents_config['backend_engineer'],
+            llm=create_llm("backend_engineer"),
+            verbose=True,
+            tools=[DockerCodeExecutor()],
+        )
+
+    @agent
+    def frontend_engineer(self) -> Agent:
+        return Agent(
+            config=self.agents_config['frontend_engineer'],
+            llm=create_llm("frontend_engineer"),
+            verbose=True,
+        )
+
+    @agent
+    def test_engineer(self) -> Agent:
+        return Agent(
+            config=self.agents_config['test_engineer'],
+            llm=create_llm("test_engineer"),
+            verbose=True,
+            tools=[DockerCodeExecutor()],
+        )
+
+    @task
+    def design_task(self) -> Task:
+        return Task(
+            config=self.tasks_config['design_task']
+        )
+
+    @task
+    def code_task(self) -> Task:
+        return Task(
+            config=self.tasks_config['code_task']
+        )
+
+    @task
+    def frontend_task(self) -> Task:
+        return Task(
+            config=self.tasks_config['frontend_task']
+        )
+
+    @task
+    def test_task(self) -> Task:
+        return Task(
+            config=self.tasks_config['test_task']
+        )
+
+    @crew
+    def crew(self) -> Crew:
+        return Crew(
+            agents=self.agents,
+            tasks=self.tasks,
+            process=Process.sequential,
+            verbose=True,
+        )

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/crew.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/crew.py
@@ -1,8 +1,19 @@
+import os
 from crewai import Agent, Crew, Process, Task
 from crewai.project import CrewBase, agent, crew, task
 
 from .llm import create_llm
 from .tools import DockerCodeExecutor
+
+callbacks = []
+_lf_public = os.environ.get("LANGFUSE_PUBLIC_KEY")
+_lf_secret = os.environ.get("LANGFUSE_SECRET_KEY")
+if _lf_public and _lf_secret:
+    try:
+        from langfuse.callback import CallbackHandler
+        callbacks.append(CallbackHandler())
+    except ImportError:
+        pass
 
 
 @CrewBase
@@ -77,4 +88,5 @@ class AdvancedEngineeringTeam():
             tasks=self.tasks,
             process=Process.sequential,
             verbose=True,
+            callbacks=callbacks,
         )

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/llm/__init__.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/llm/__init__.py
@@ -1,0 +1,8 @@
+from .factory import create_llm
+from .config import get_all_agent_models, get_model_string_for_role
+
+__all__ = [
+    "create_llm",
+    "get_all_agent_models",
+    "get_model_string_for_role",
+]

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/llm/config.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/llm/config.py
@@ -1,0 +1,37 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+# Environment variable names for each agent role
+ENG_LEAD = "ENG_LEAD_MODEL"
+BACKEND = "BACKEND_ENGINEER_MODEL"
+FRONTEND = "FRONTEND_ENGINEER_MODEL"
+TESTER = "TEST_ENGINEER_MODEL"
+
+# Maps agent role (as named in agents.yaml / crew.py) → env var name
+ROLE_ENV_MAP = {
+    "engineering_lead": ENG_LEAD,
+    "backend_engineer": BACKEND,
+    "frontend_engineer": FRONTEND,
+    "test_engineer": TESTER,
+}
+
+
+def get_model_string_for_role(role: str) -> str:
+    """Get model string (e.g. 'groq/llama-3.3-70b-versatile') for an agent role."""
+    env_var = ROLE_ENV_MAP.get(role)
+    if not env_var:
+        raise ValueError(f"Unknown role: {role}. Valid: {list(ROLE_ENV_MAP.keys())}")
+    value = os.getenv(env_var)
+    if not value:
+        raise ValueError(
+            f"Missing env var {env_var} for role '{role}'. "
+            f"Set it in .env or check .env.example"
+        )
+    return value
+
+
+def get_all_agent_models() -> dict:
+    """Return mapping of role → model string for all agents."""
+    return {role: get_model_string_for_role(role) for role in ROLE_ENV_MAP}

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/llm/factory.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/llm/factory.py
@@ -1,0 +1,17 @@
+from crewai import LLM
+
+from .config import get_model_string_for_role
+
+
+def create_llm(role: str) -> LLM:
+    """Create a CrewAI LLM for a given agent role.
+
+    Args:
+        role: Agent role key like "engineering_lead", "backend_engineer",
+              "frontend_engineer", or "test_engineer".
+
+    Returns:
+        A CrewAI LLM instance configured to use the model specified for that role.
+    """
+    model_string = get_model_string_for_role(role)
+    return LLM(model=model_string)

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/main.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/main.py
@@ -88,8 +88,23 @@ def _extract_code_from_markdown(text: str) -> str:
             seen_def = True
         if seen_def:
             code_lines.append(line)
+
     if code_lines:
-        return "\n".join(code_lines)
+        return _find_valid_python(code_lines)
+
+    return stripped
+
+
+def _find_valid_python(lines: list[str]) -> str:
+    """Find the longest valid Python prefix from a list of lines."""
+    for i in range(len(lines), 0, -1):
+        block = "\n".join(lines[:i])
+        try:
+            compile(block, "<output>", "exec")
+            return block.strip()
+        except SyntaxError:
+            continue
+    return "\n".join(lines).strip()
 
     return stripped
 

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/main.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/main.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+import os
+import re
+import sys
+import argparse
+import warnings
+
+warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
+
+from .crew import AdvancedEngineeringTeam
+
+DEFAULT_REQUIREMENTS = """
+A simple account management system for a trading simulation platform.
+The system should allow users to create an account, deposit funds, and withdraw funds.
+The system should allow users to record that they have bought or sold shares, providing a quantity.
+The system should calculate the total value of the user's portfolio, and the profit or loss from the initial deposit.
+The system should be able to report the holdings of the user at any point in time.
+The system should be able to report the profit or loss of the user at any point in time.
+The system should be able to list the transactions that the user has made over time.
+The system should prevent the user from withdrawing funds that would leave them with a negative balance, or
+ from buying more shares than they can afford, or selling shares that they don't have.
+ The system has access to a function get_share_price(symbol) which returns the current price of a share,
+ and includes a test implementation that returns fixed prices for AAPL, TSLA, GOOGL.
+"""
+
+OUTPUT_DIR = "output"
+
+
+def clean_output_files(module_name: str):
+    """Strip markdown from generated .py files, extract code blocks."""
+    py_files = [
+        os.path.join(OUTPUT_DIR, module_name),
+        os.path.join(OUTPUT_DIR, "app.py"),
+        os.path.join(OUTPUT_DIR, f"test_{module_name}"),
+    ]
+    for filepath in py_files:
+        if not os.path.exists(filepath):
+            continue
+        with open(filepath, "r") as f:
+            content = f.read()
+
+        cleaned = _extract_code_from_markdown(content)
+        if cleaned and cleaned != content:
+            with open(filepath, "w") as f:
+                f.write(cleaned)
+            print(f"  Cleaned markdown from {filepath}")
+        elif not cleaned and content.strip():
+            with open(filepath, "w") as f:
+                f.write(content)
+        elif not content.strip():
+            print(f"  Warning: {filepath} is empty")
+
+
+def _extract_code_from_markdown(text: str) -> str:
+    """Extract Python code from LLM output.
+
+    Prefers content inside ```python...``` blocks.
+    Falls back to extracting def/class/import lines if no blocks found.
+    Strips <think> blocks and leading prose.
+    """
+    text = re.sub(r"(?s)<think>.*?</think>", "", text)
+
+    lines = text.split("\n")
+    in_block = False
+    blocks = []
+    current = []
+    for line in lines:
+        if line.strip().startswith("```"):
+            if in_block:
+                blocks.append("\n".join(current))
+                current = []
+            in_block = not in_block
+            continue
+        if in_block:
+            current.append(line)
+
+    if blocks:
+        return max(blocks, key=len).strip()
+
+    text = re.sub(r"```[a-z]*", "", text)
+    lines = [l for l in text.split("\n") if not l.strip().startswith("```")]
+    stripped = "\n".join(lines).strip()
+
+    code_lines = []
+    seen_def = False
+    for line in stripped.split("\n"):
+        if re.match(r"^(import |from |def |class |@)", line):
+            seen_def = True
+        if seen_def:
+            code_lines.append(line)
+    if code_lines:
+        return "\n".join(code_lines)
+
+    return stripped
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Advanced Engineering Team — multi-agent software development"
+    )
+    parser.add_argument(
+        "--requirements", "-r",
+        type=str, default=None,
+        help="Custom requirements. If omitted, uses default trading account system."
+    )
+    parser.add_argument(
+        "--module", "-m",
+        type=str, default="accounts.py",
+        help="Output module name (default: accounts.py)"
+    )
+    parser.add_argument(
+        "--class-name", "-c",
+        type=str, default="Account",
+        help="Main class name (default: Account)"
+    )
+    return parser.parse_args()
+
+
+def run():
+    args = parse_args()
+
+    requirements = args.requirements
+    if not requirements and not sys.stdin.isatty():
+        requirements = sys.stdin.read().strip()
+    if not requirements:
+        requirements = DEFAULT_REQUIREMENTS
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    inputs = {
+        "requirements": requirements.strip(),
+        "module_name": args.module,
+        "class_name": args.class_name,
+    }
+
+    print(f"\n{'='*60}")
+    print(f"  Advanced Engineering Team")
+    print(f"  Module: {args.module}  |  Class: {args.class_name}")
+    print(f"{'='*60}\n")
+
+    team = AdvancedEngineeringTeam()
+
+    try:
+        result = team.crew().kickoff(inputs=inputs)
+        clean_output_files(args.module)
+        print(f"\n{'='*60}")
+        print(f"  Done! Output files in ./{OUTPUT_DIR}/")
+        print(f"{'='*60}\n")
+    except Exception as e:
+        print(f"\nError running crew: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run()

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/tools/__init__.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/tools/__init__.py
@@ -1,0 +1,3 @@
+from .docker_executor import DockerCodeExecutor
+
+__all__ = ["DockerCodeExecutor"]

--- a/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/tools/docker_executor.py
+++ b/3_crew/community_contributions/advanced-engineering-team/src/advanced_engineering_team/tools/docker_executor.py
@@ -1,0 +1,67 @@
+import tempfile
+import os
+import subprocess
+from typing import Type
+
+from pydantic import BaseModel, Field
+
+from crewai.tools import BaseTool
+
+
+class DockerExecutorInput(BaseModel):
+    """Input schema for Docker code execution."""
+    code: str = Field(..., description="Python3 code to execute. ALWAYS print the final result.")
+    libraries: str = Field(
+        default="",
+        description="Comma-separated list of pip packages to install, e.g. 'requests,pandas'"
+    )
+
+
+class DockerCodeExecutor(BaseTool):
+    name: str = "Docker Code Executor"
+    description: str = (
+        "Executes Python code inside a Docker container and returns the output. "
+        "Use this to test and validate Python code."
+    )
+    args_schema: Type[BaseModel] = DockerExecutorInput
+
+    def _run(self, code: str, libraries: str = "") -> str:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = os.path.join(tmpdir, "script.py")
+            with open(script_path, "w") as f:
+                f.write(code)
+
+            dockerfile = ["FROM python:3.12-slim"]
+            if libraries:
+                pkgs = [p.strip() for p in libraries.split(",") if p.strip()]
+                if pkgs:
+                    dockerfile.append(f"RUN pip install {' '.join(pkgs)} || echo 'Some packages failed to install'")
+            dockerfile.append("COPY script.py /script.py")
+            dockerfile.append("CMD python /script.py")
+
+            with open(os.path.join(tmpdir, "Dockerfile"), "w") as f:
+                f.write("\n".join(dockerfile))
+
+            try:
+                result = subprocess.run(
+                    ["docker", "build", "-q", "-t", "crew-exec", tmpdir],
+                    capture_output=True, text=True, timeout=120
+                )
+                if result.returncode != 0:
+                    return f"Build error:\n{result.stderr.strip()}"
+
+                result = subprocess.run(
+                    ["docker", "run", "--rm", "crew-exec"],
+                    capture_output=True, text=True, timeout=60
+                )
+                output = result.stdout.strip()
+                if result.stderr:
+                    output += f"\n(Stderr: {result.stderr.strip()})"
+                return output if output else "(No output)"
+
+            except subprocess.TimeoutExpired:
+                return "Error: Execution timed out"
+            except FileNotFoundError:
+                return "Error: Docker not found. Is Docker running?"
+            except Exception as e:
+                return f"Error: {e}"


### PR DESCRIPTION
An end-to-end multi-agent software engineering team built with CrewAI, using only free-tier models from Groq (4 different models, separate rate limit pools), with custom Docker code execution and LangFuse observability.

What it does Takes a natural-language requirements spec, then runs a sequential 4-agent pipeline: Engineering Lead produces a design document → Backend Engineer writes the Python module → Frontend Engineer builds a Gradio UI → QA Engineer writes and runs unit tests. All output goes to ./output/. Entire pipeline traced in LangFuse.

Labs covered

Lab 3 (Week 3): @CrewBase class, 4 agents with per-role config, Process.sequential, task chaining via context, output_file
Custom tool: DockerCodeExecutor — replaces CrewAI's buggy built-in Code Interpreter, builds and runs code in Docker containers
Multi-provider LLM routing: LiteLLM with 4 different Groq models, each in a separate rate limit pool
Post-processing: strips <think> tags and markdown from generated files using ast.parse() validation