### PR TITLE
fix: migrate deprecated LangChain imports

### DIFF
--- a/4_langgraph/2_lab2.ipynb
+++ b/4_langgraph/2_lab2.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.agents import Tool\n",
+    "from langchain_core.tools import Tool\n",
     "\n",
     "tool_search =Tool(\n",
     "        name=\"search\",\n",

--- a/4_langgraph/3_lab3.ipynb
+++ b/4_langgraph/3_lab3.ipynb
@@ -25,7 +25,7 @@
     "from langgraph.prebuilt import ToolNode, tools_condition\n",
     "import requests\n",
     "import os\n",
-    "from langchain.agents import Tool\n",
+    "from langchain_core.tools import Tool\n",
     "\n",
     "from langchain_openai import ChatOpenAI\n",
     "from langgraph.checkpoint.memory import MemorySaver"

--- a/4_langgraph/community_contributions/yemigabriel/sidekick_tools.py
+++ b/4_langgraph/community_contributions/yemigabriel/sidekick_tools.py
@@ -3,7 +3,7 @@ from langchain_community.agent_toolkits import PlayWrightBrowserToolkit
 from dotenv import load_dotenv
 import os
 import requests
-from langchain.agents import Tool
+from langchain_core.tools import Tool
 from langchain_community.agent_toolkits import FileManagementToolkit
 from langchain_community.tools.wikipedia.tool import WikipediaQueryRun
 from langchain_experimental.tools import PythonREPLTool

--- a/4_langgraph/sidekick_tools.py
+++ b/4_langgraph/sidekick_tools.py
@@ -3,7 +3,7 @@ from langchain_community.agent_toolkits import PlayWrightBrowserToolkit
 from dotenv import load_dotenv
 import os
 import requests
-from langchain.agents import Tool
+from langchain_core.tools import Tool
 from langchain_community.agent_toolkits import FileManagementToolkit
 from langchain_community.tools.wikipedia.tool import WikipediaQueryRun
 from langchain_experimental.tools import PythonREPLTool

--- a/5_autogen/2_lab2_autogen_agentchat.ipynb
+++ b/5_autogen/2_lab2_autogen_agentchat.ipynb
@@ -163,7 +163,7 @@
     "\n",
     "from langchain_community.utilities import GoogleSerperAPIWrapper\n",
     "from langchain_community.agent_toolkits import FileManagementToolkit\n",
-    "from langchain.agents import Tool\n",
+    "from langchain_core.tools import Tool\n",
     "\n",
     "\n",
     "prompt = \"\"\"Your task is to find a one-way non-stop flight from JFK to LHR in June 2025.\n",
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
     "\n",
     "from autogen_ext.tools.langchain import LangChainToolAdapter\n",
     "from langchain_community.utilities import GoogleSerperAPIWrapper\n",
-    "from langchain.agents import Tool\n",
+    "from langchain_core.tools import Tool\n",
     "\n",
     "serper = GoogleSerperAPIWrapper()\n",
     "langchain_serper =Tool(name=\"internet_search\", func=serper.run, description=\"useful for when you need to search the internet\")\n",

--- a/5_autogen/4_lab4_autogen_distributed.ipynb
+++ b/5_autogen/4_lab4_autogen_distributed.ipynb
@@ -26,7 +26,7 @@
     "from autogen_ext.models.openai import OpenAIChatCompletionClient\n",
     "from autogen_ext.tools.langchain import LangChainToolAdapter\n",
     "from langchain_community.utilities import GoogleSerperAPIWrapper\n",
-    "from langchain.agents import Tool\n",
+    "from langchain_core.tools import Tool\n",
     "from IPython.display import display, Markdown\n",
     "\n",
     "from dotenv import load_dotenv\n",


### PR DESCRIPTION
## Changes
- Replaced deprecated LangChain imports with their new locations.
- Updated `Tool` imports from:
  `from langchain.agents import Tool`
  to:
  `from langchain_core.tools import Tool`

