### PR TITLE
fix: work around Windows Jupyter stderr incompatibility

### DIFF
--- a/6_mcp/backend/accounts_client.py
+++ b/6_mcp/backend/accounts_client.py
@@ -1,7 +1,29 @@
+import sys
 import mcp
 from pathlib import Path
 from mcp.client.stdio import stdio_client
 from mcp import StdioServerParameters
+
+
+if sys.platform.startswith("win"):
+    # Under Windows, IPykernel's sys.stderr is not backed by a real file
+    # descriptor. Redirect errlog to DEVNULL to avoid
+    #   io.UnsupportedOperation: fileno
+    # when stdio_client creates its subprocess.
+    try:
+        from IPython import get_ipython
+
+        if get_ipython().__class__.__name__ == "ZMQInteractiveShell":
+            import functools
+            import subprocess
+
+            # we are running inside Jupyter under Windows so redirect errlog
+            stdio_client = functools.partial(
+                stdio_client,
+                errlog=subprocess.DEVNULL,
+            )
+    except (ImportError, ModuleNotFoundError, AttributeError, ):
+        pass
 
 params = StdioServerParameters(
     command="uv",
@@ -9,14 +31,14 @@ params = StdioServerParameters(
     cwd=str(Path(__file__).resolve().parent.parent),
     env=None,
 )
-            
+
 async def read_accounts_resource(name):
     async with stdio_client(params) as streams:
         async with mcp.ClientSession(*streams) as session:
             await session.initialize()
             result = await session.read_resource(f"accounts://accounts_server/{name}")
             return result.contents[0].text
-        
+
 async def read_strategy_resource(name):
     async with stdio_client(params) as streams:
         async with mcp.ClientSession(*streams) as session:


### PR DESCRIPTION
When running under IPykernel (e.g. Jupyter Notebook/Lab or VS Code notebooks) on Windows, sys.stderr is not backed by a real file descriptor and fileno() raises io.UnsupportedOperation. 

Passing subprocess.DEVNULL avoids this incompatibility.
It is minimally invasive, leaving the behavior unchanged everywhere else.
It is designed to not affect Non-Windows users and/or users who are not running from a Jupyter notebook.
