### PR TITLE
fix:  allow the latest playwright to browse local files

### DIFF
--- a/5_agent_frameworks/5_agent_loop/qa_agent.py
+++ b/5_agent_frameworks/5_agent_loop/qa_agent.py
@@ -60,7 +60,13 @@ async def judge_game(language: str, objective: str, uri: str) -> dict | None:
         verdict["note"] = note
         return {"recorded": True}
 
-    args = ["-y", "@playwright/mcp@latest", "--browser", "chrome", "--isolated"]
+    args = [
+        "-y",
+        "@playwright/mcp@latest",
+        "--browser", "chrome",
+        "--isolated",
+        "--allow-unrestricted-file-access"
+    ]
     if os.environ.get("QA_HEADLESS") == "1":
         args.append("--headless")
     browser = McpToolset(


### PR DESCRIPTION
Playwright security seems to have been recently hardened to restrict the browsing of any local files.
It makes sense.
In our case though, we point playwright's MCP server at specific local files like game.html, which we know to be safe.
We can overcome Playwright's reluctance to browse locally by adding a single parameter to the args list for the MCP Server: 
`"--allow-unrestricted-file-access"`
 