### PR TITLE
Week 6: Kirundi Study Brain MCP (Sama-ndari)

### DIFF
--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/.env.example
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/.env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=sk-your-key-here
+KIRUNDI_BRAIN_MODEL=gpt-4o-mini
+# Optional overrides (defaults: ./brain and ./data next to server.py)
+# KIRUNDI_BRAIN_DIR=
+# KIRUNDI_BRAIN_DATA_DIR=

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/.gitignore
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/.gitignore
@@ -1,0 +1,9 @@
+.venv/
+__pycache__/
+*.py[cod]
+.env
+data/*.sqlite3
+data/*.db
+.DS_Store
+.pytest_cache/
+.ruff_cache/

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/README.md
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/README.md
@@ -1,0 +1,89 @@
+# Kirundi Study Brain (Week 6 MCP)
+
+Local-first **Kirundi (Rundi)** study coach exposed as a **FastMCP** server. An OpenAI Agents SDK demo attaches over stdio, calls path-jailed Brain tools, and tutors from a Markdown corpus — not from thin air.
+
+Inspired by the course trading/MCP labs and pro patterns like `asket-mcp` (Brain + profile + gated writes), scoped to Burundi language learning.
+
+## Architecture
+
+```
+demo_agent.py  →  MCPServerStdio  →  server.py (FastMCP)
+                                         │
+                    ┌────────────────────┼────────────────────┐
+                    ▼                    ▼                    ▼
+              brain/*.md           SQLite profile        ask / grade
+              (path jail)          (data/)               (OpenAI + retrieve)
+```
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `brain_list_files` | List corpus entries |
+| `brain_read_file` | Read a lesson |
+| `brain_search_notes` | Keyword search in `.md` |
+| `brain_write_markdown` | Add/update lesson (`overwrite` gated) |
+| `brain_delete_file` | Delete lesson (confirm gated) |
+| `profile_get` / `profile_update` | Learner level, goals, mistakes |
+| `ask_kirundi_tutor` | Retrieve + grounded answer |
+| `grade_kirundi_answer` | Score a short reply |
+| `kirundi_brain_info` | Paths / version / config |
+
+## Setup
+
+```bash
+cd 6_mcp/community_contributions/Sama-ndari_kirundi-brain
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # set OPENAI_API_KEY
+```
+
+### Run MCP server alone (stdio — Cursor / Claude Desktop)
+
+```bash
+python server.py
+```
+
+Example Cursor `mcp.json` fragment (adjust absolute paths):
+
+```json
+{
+  "mcpServers": {
+    "kirundi-study-brain": {
+      "command": "python",
+      "args": ["/ABS/PATH/Sama-ndari_kirundi-brain/server.py"],
+      "env": {
+        "OPENAI_API_KEY": "sk-...",
+        "KIRUNDI_BRAIN_DIR": "/ABS/PATH/Sama-ndari_kirundi-brain/brain",
+        "KIRUNDI_BRAIN_DATA_DIR": "/ABS/PATH/Sama-ndari_kirundi-brain/data"
+      }
+    }
+  }
+}
+```
+
+### Run agent demo
+
+```bash
+python demo_agent.py "How do I say thank you in Kirundi?"
+python demo_agent.py "Quiz me on greetings"
+```
+
+## Sample corpus
+
+Bundled under `brain/`: greetings, courtesy, numbers, food. Point `KIRUNDI_BRAIN_DIR` at a larger phrase bank when you have one.
+
+## Env
+
+| Variable | Role |
+|----------|------|
+| `OPENAI_API_KEY` | Required for agent demo + `ask` / `grade` |
+| `KIRUNDI_BRAIN_MODEL` | Default `gpt-4o-mini` |
+| `KIRUNDI_BRAIN_DIR` | Corpus root (default: `./brain`) |
+| `KIRUNDI_BRAIN_DATA_DIR` | SQLite dir (default: `./data`) |
+
+Do not commit `.env` or `data/*.sqlite3`.
+
+## Author
+
+[Sama-ndari](https://github.com/Sama-ndari) — https://www.samandari.dev

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/README.md
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/README.md
@@ -1,0 +1,13 @@
+# Kirundi Brain corpus
+
+Sample lessons for the Kirundi Study Brain MCP.
+
+- `greetings.md` — Amakuru, Muraho, time-of-day greetings
+- `courtesy.md` — thanks, please, apology
+- `numbers.md` — 1–10
+- `food.md` — market and drinks
+
+Add your own `.md` lessons here (or point `KIRUNDI_BRAIN_DIR` at a larger corpus).
+Keep entries short and table-friendly so keyword retrieval works well.
+
+Related projects by the author: Kirundi datasets / Ijwi work — expand this Brain from real phrase banks when contributing beyond the course sample.

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/courtesy.md
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/courtesy.md
@@ -1,0 +1,24 @@
+# Courtesy — Gusaba no gushimira
+
+Polite phrases for thanks, please, and apology.
+
+| Kirundi | English |
+|---------|---------|
+| Urakoze | Thank you (singular) |
+| Murakoze | Thank you (plural / respectful) |
+| Urakoze cane | Thank you very much |
+| Ndagusavye | Please (I request you) |
+| Mbabarira | Excuse me / Forgive me |
+| Nta kibazo | No problem |
+| Ego | Yes |
+| Oya | No |
+| Ndagushimiye | I appreciate you |
+
+## Example
+
+Visitor: Murakoze cane.
+Host: Nta kibazo. Karibu. (You're welcome / No problem. Welcome.)
+
+## Tip
+
+Use **Mu-** forms (*Murakoze*, *Mwaramutse*) with elders or groups — shows respect.

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/food.md
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/food.md
@@ -1,0 +1,28 @@
+# Food & market — Ibiryo n'isoko
+
+Useful words around meals and markets in Burundi.
+
+| Kirundi | English |
+|---------|---------|
+| Amazi | Water |
+| Icayi | Tea |
+| Ikawa | Coffee |
+| Umuceri | Rice |
+| Ibiharage | Beans |
+| Inyama | Meat |
+| Ifi | Fish |
+| Isoko | Market |
+| Igiciro | Price |
+| Angahe? | How much? |
+| Birazimvye | It's expensive |
+| Birazimbutse | It's cheap / affordable |
+| Ndashaka... | I want... |
+
+## Example
+
+Buyer: Amazi agurwa angahe?
+Seller: Amafaranga mirongo itanu. (e.g. fifty — amounts vary; ask locally)
+
+## Tip
+
+Coffee and tea culture is strong — *Ikawa* and *Icayi* are everyday words.

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/greetings.md
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/greetings.md
@@ -1,0 +1,24 @@
+# Greetings — Amakuru
+
+Basic Kirundi greetings for everyday use in Burundi.
+
+| Kirundi | English | Notes |
+|---------|---------|-------|
+| Bite? | Hi / How's it? | Informal, very common |
+| Amakuru? | How are you? / What's the news? | Standard greeting |
+| Ni meza | I'm fine / It's good | Reply to Amakuru? |
+| Amakuru yawe? | How about you? | Return the question |
+| Mwaramutse | Good morning | Morning greeting |
+| Mwiriwe | Good afternoon / Good evening | Later in the day |
+| Ijoro ryiza | Good night | Night farewell |
+| Muraho | Hello (respectful) | Polite / plural form often used |
+
+## Example dialogue
+
+A: Amakuru?
+B: Ni meza. Amakuru yawe?
+A: Ni meza cane. (I'm very well.)
+
+## Tip
+
+`cane` intensifies: *meza cane* = very good.

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/numbers.md
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/brain/numbers.md
@@ -1,0 +1,23 @@
+# Numbers — Imibare 1–10
+
+| Number | Kirundi |
+|--------|---------|
+| 1 | rimwe |
+| 2 | kabiri |
+| 3 | gatatu |
+| 4 | kane |
+| 5 | gatanu |
+| 6 | gatandatu |
+| 7 | indwi |
+| 8 | umunani |
+| 9 | icenda |
+| 10 | icumi |
+
+## Examples
+
+- I have two books → Mfise ibitabo **bibiri** (agreement forms vary; start with the cardinal roots above).
+- Three people → Abantu **batatu**.
+
+## Tip
+
+Kirundi noun-class agreement changes number words; learn the roots first, then agreement with a teacher.

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/demo_agent.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/demo_agent.py
@@ -1,0 +1,73 @@
+"""
+Week 6 demo: OpenAI Agents SDK + Kirundi Brain MCP (stdio).
+
+Usage (from this directory):
+  python -m venv .venv && source .venv/bin/activate
+  pip install -r requirements.txt
+  cp .env.example .env   # add OPENAI_API_KEY
+  python demo_agent.py "Teach me Kirundi greetings"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from agents import Agent, Runner, trace
+from agents.mcp import MCPServerStdio
+from dotenv import load_dotenv
+
+_CONTRIB = Path(__file__).resolve().parent
+load_dotenv(_CONTRIB / ".env", override=True)
+
+INSTRUCTIONS = """
+You are a Kirundi (Rundi) study coach for learners interested in Burundi.
+You ONLY know what your MCP tools return from the Kirundi Brain.
+
+Rules:
+- Call tools before teaching vocabulary; do not invent phrases.
+- Prefer brain_search_notes / brain_read_file / ask_kirundi_tutor.
+- Check profile_get once per session; update profile after clear mistakes.
+- Keep replies short: phrase, meaning, one example, optional tip.
+- For destructive writes/deletes, ask the human first, then pass the confirm flags.
+"""
+
+
+async def run_demo(user_query: str) -> str:
+    """Run one agent turn with the Kirundi Brain MCP server attached."""
+    if not (os.getenv("OPENAI_API_KEY") or "").strip():
+        raise RuntimeError("Set OPENAI_API_KEY in .env before running the demo agent.")
+
+    env = {
+        **os.environ,
+        "KIRUNDI_BRAIN_DIR": str(_CONTRIB / "brain"),
+        "KIRUNDI_BRAIN_DATA_DIR": str(_CONTRIB / "data"),
+    }
+    params = {
+        "command": sys.executable,
+        "args": [str(_CONTRIB / "server.py")],
+        "cwd": str(_CONTRIB),
+        "env": env,
+    }
+
+    async with MCPServerStdio(params=params, client_session_timeout_seconds=60) as server:
+        agent = Agent(
+            name="KirundiCoach",
+            instructions=INSTRUCTIONS,
+            model=os.getenv("KIRUNDI_BRAIN_MODEL", "gpt-4o-mini"),
+            mcp_servers=[server],
+        )
+        with trace("kirundi_brain_demo"):
+            result = await Runner.run(agent, user_query)
+        return str(result.final_output)
+
+
+def main() -> None:
+    query = " ".join(sys.argv[1:]).strip() or "Teach me basic Kirundi greetings for a visitor."
+    print(asyncio.run(run_demo(query)))
+
+
+if __name__ == "__main__":
+    main()

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/__init__.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/__init__.py
@@ -1,0 +1,3 @@
+"""Kirundi Study Brain — local-first MCP package."""
+
+__version__ = "0.1.0"

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/brain_fs.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/brain_fs.py
@@ -1,0 +1,165 @@
+"""Path-jailed filesystem helpers for the Kirundi Markdown corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_under_root(root: Path, relative: str) -> Path:
+    """Resolve a relative path; raise ValueError if it escapes root."""
+    rel = (relative or ".").strip() or "."
+    parts = Path(rel).parts
+    if rel.startswith("/") or ".." in parts:
+        raise ValueError("Path must be relative to the Brain root (no '..').")
+    candidate = (root / rel).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError("Path escapes Brain root.") from exc
+    return candidate
+
+
+def list_directory(root: Path, relative_path: str = ".", max_entries: int = 200) -> str:
+    """List entries under a Brain-relative path."""
+    try:
+        target = resolve_under_root(root, relative_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+    if not target.exists():
+        return f"Path does not exist: {relative_path}"
+    if target.is_file():
+        return f"Not a directory: {relative_path}"
+    names: list[str] = []
+    try:
+        for path in sorted(target.iterdir())[:max_entries]:
+            names.append(path.name + ("/" if path.is_dir() else ""))
+    except OSError as exc:
+        return f"Error listing directory: {exc}"
+    return "\n".join(names) if names else "(empty)"
+
+
+def read_text(root: Path, relative_path: str, max_chars: int = 40_000) -> str:
+    """Read a UTF-8 text file from the Brain."""
+    try:
+        target = resolve_under_root(root, relative_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+    if not target.is_file():
+        return f"Not a file (or missing): {relative_path}"
+    try:
+        text = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        return f"Error reading file: {exc}"
+    if len(text) > max_chars:
+        return text[:max_chars] + f"\n\n... [truncated {len(text) - max_chars} chars]"
+    return text
+
+
+def write_markdown(
+    root: Path,
+    relative_path: str,
+    content: str,
+    *,
+    overwrite: bool = False,
+) -> str:
+    """Write Markdown into the Brain; require overwrite=True to replace."""
+    try:
+        target = resolve_under_root(root, relative_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+    if target.exists() and not overwrite:
+        return (
+            f"File exists: {relative_path}. "
+            "Set overwrite=true only after the learner confirms replacement."
+        )
+    if target.exists() and target.is_dir():
+        return f"Error: path is a directory: {relative_path}"
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        return f"Error writing file: {exc}"
+    return f"Wrote Brain file: {relative_path}"
+
+
+def delete_file(root: Path, relative_path: str, *, confirmed: bool = False) -> str:
+    """Delete a Brain file; require confirmed=True after explicit approval."""
+    if not confirmed:
+        return (
+            "Deletion blocked. Set user_confirmed_deletion=true "
+            "only after the learner explicitly approves."
+        )
+    try:
+        target = resolve_under_root(root, relative_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+    if not target.is_file():
+        return f"Not a file (or missing): {relative_path}"
+    try:
+        target.unlink()
+    except OSError as exc:
+        return f"Error deleting file: {exc}"
+    return f"Deleted Brain file: {relative_path}"
+
+
+def search_markdown(
+    root: Path,
+    query: str,
+    under_subpath: str = ".",
+    max_file_hits: int = 20,
+) -> str:
+    """Case-insensitive keyword search across .md files under the Brain."""
+    needle = (query or "").strip()
+    if not needle:
+        return "Error: query is empty."
+    try:
+        base = resolve_under_root(root, under_subpath)
+    except ValueError as exc:
+        return f"Error: {exc}"
+    if not base.exists():
+        return f"Path does not exist: {under_subpath}"
+
+    hits: list[str] = []
+    files = sorted(base.rglob("*.md")) if base.is_dir() else []
+    if base.is_file() and base.suffix == ".md":
+        files = [base]
+
+    for path in files:
+        if len(hits) >= max_file_hits:
+            break
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        lower = text.lower()
+        q = needle.lower()
+        if q not in lower:
+            continue
+        idx = lower.find(q)
+        start = max(0, idx - 60)
+        end = min(len(text), idx + len(needle) + 60)
+        snippet = text[start:end].replace("\n", " ")
+        rel = path.relative_to(root.resolve()).as_posix()
+        hits.append(f"- {rel}: ...{snippet}...")
+
+    if not hits:
+        return f"No matches for {needle!r}."
+    return f"Found {len(hits)} file(s):\n" + "\n".join(hits)
+
+
+def collect_context(root: Path, query: str, max_chars: int = 6_000) -> str:
+    """Gather Markdown snippets for RAG-style tutoring."""
+    search_result = search_markdown(root, query, max_file_hits=8)
+    if search_result.startswith("No matches") or search_result.startswith("Error"):
+        # Fall back to concatenating short lesson intros.
+        parts: list[str] = []
+        for path in sorted(root.rglob("*.md"))[:6]:
+            try:
+                body = path.read_text(encoding="utf-8")[:800]
+            except OSError:
+                continue
+            rel = path.relative_to(root.resolve()).as_posix()
+            parts.append(f"### {rel}\n{body}")
+        blob = "\n\n".join(parts)
+        return blob[:max_chars] if blob else "Corpus is empty."
+    return search_result[:max_chars]

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/config.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/config.py
@@ -1,0 +1,45 @@
+"""Environment-backed settings for the Kirundi Brain MCP server."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional until deps installed
+    load_dotenv = None
+
+_CONTRIB_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_BRAIN = _CONTRIB_ROOT / "brain"
+_DEFAULT_DATA = _CONTRIB_ROOT / "data"
+
+if load_dotenv is not None:
+    load_dotenv(_CONTRIB_ROOT / ".env", override=False)
+
+
+def brain_root() -> Path:
+    """Return the allow-listed Markdown corpus directory."""
+    raw = (os.getenv("KIRUNDI_BRAIN_DIR") or "").strip()
+    root = Path(raw).expanduser().resolve() if raw else _DEFAULT_BRAIN.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def data_dir() -> Path:
+    """Return the local data directory (SQLite profile, etc.)."""
+    raw = (os.getenv("KIRUNDI_BRAIN_DATA_DIR") or "").strip()
+    path = Path(raw).expanduser().resolve() if raw else _DEFAULT_DATA.resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def openai_api_key() -> str | None:
+    """Return OPENAI_API_KEY if set."""
+    key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    return key or None
+
+
+def openai_model() -> str:
+    """Return chat model id for ask_kirundi."""
+    return (os.getenv("KIRUNDI_BRAIN_MODEL") or "gpt-4o-mini").strip()

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/profile_store.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/profile_store.py
@@ -1,0 +1,90 @@
+"""SQLite learner profile for Kirundi study coaching."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+
+class ProfileStore:
+    """Persist learner level, goals, and recent mistakes."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS profile (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    display_name TEXT NOT NULL DEFAULT 'Learner',
+                    level TEXT NOT NULL DEFAULT 'A1',
+                    goals TEXT NOT NULL DEFAULT '[]',
+                    recent_mistakes TEXT NOT NULL DEFAULT '[]',
+                    notes TEXT NOT NULL DEFAULT ''
+                )
+                """
+            )
+            row = conn.execute("SELECT id FROM profile WHERE id = 1").fetchone()
+            if row is None:
+                conn.execute("INSERT INTO profile (id) VALUES (1)")
+            conn.commit()
+
+    def get(self) -> dict:
+        """Return the single learner profile as a dict."""
+        with self._connect() as conn:
+            row = conn.execute("SELECT * FROM profile WHERE id = 1").fetchone()
+        if row is None:
+            return {}
+        return {
+            "display_name": row["display_name"],
+            "level": row["level"],
+            "goals": json.loads(row["goals"]),
+            "recent_mistakes": json.loads(row["recent_mistakes"]),
+            "notes": row["notes"],
+        }
+
+    def update(
+        self,
+        *,
+        display_name: str | None = None,
+        level: str | None = None,
+        goals: list[str] | None = None,
+        recent_mistakes: list[str] | None = None,
+        notes: str | None = None,
+    ) -> dict:
+        """Patch profile fields that are provided; return updated profile."""
+        current = self.get()
+        next_name = display_name if display_name is not None else current["display_name"]
+        next_level = level if level is not None else current["level"]
+        next_goals = goals if goals is not None else current["goals"]
+        next_mistakes = (
+            recent_mistakes if recent_mistakes is not None else current["recent_mistakes"]
+        )
+        next_notes = notes if notes is not None else current["notes"]
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE profile
+                SET display_name = ?, level = ?, goals = ?, recent_mistakes = ?, notes = ?
+                WHERE id = 1
+                """,
+                (
+                    next_name,
+                    next_level,
+                    json.dumps(next_goals, ensure_ascii=False),
+                    json.dumps(next_mistakes, ensure_ascii=False),
+                    next_notes,
+                ),
+            )
+            conn.commit()
+        return self.get()

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/tutor.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/kirundi_brain/tutor.py
@@ -1,0 +1,107 @@
+"""RAG-lite tutor: retrieve corpus snippets, then ask OpenAI with grounding."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from kirundi_brain import brain_fs, config
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM = """You are a careful Kirundi (Rundi) language tutor for Burundi.
+Use ONLY the provided corpus context for vocabulary and phrasing.
+If the context is insufficient, say what is missing and suggest which Brain lesson to open.
+Keep answers short: phrase, meaning, one example sentence, pronunciation tip when useful.
+Prefer Kirundi orthography used in the corpus."""
+
+
+def ask_kirundi(root: Path, question: str, learner_level: str = "A1") -> str:
+    """Answer a Kirundi question grounded in Brain Markdown + optional OpenAI."""
+    q = (question or "").strip()
+    if not q:
+        return "Error: question is empty."
+
+    context = brain_fs.collect_context(root, q)
+    key = config.openai_api_key()
+    if not key:
+        return (
+            "OPENAI_API_KEY is not set. Retrieved corpus context only:\n\n"
+            f"{context}"
+        )
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        return "openai package is not installed. Retrieved context only:\n\n" + context
+
+    client = OpenAI(api_key=key)
+    user_prompt = (
+        f"Learner level: {learner_level}\n\n"
+        f"Corpus context:\n{context}\n\n"
+        f"Question: {q}"
+    )
+    try:
+        completion = client.chat.completions.create(
+            model=config.openai_model(),
+            messages=[
+                {"role": "system", "content": _SYSTEM},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.3,
+        )
+    except Exception as exc:
+        logger.exception("ask_kirundi OpenAI call failed")
+        return f"OpenAI error: {exc}\n\nCorpus context:\n{context}"
+
+    answer = (completion.choices[0].message.content or "").strip()
+    return answer or "Model returned an empty answer."
+
+
+def grade_answer(
+    root: Path,
+    prompt_en: str,
+    learner_reply: str,
+    expected_hint: str = "",
+) -> str:
+    """Grade a short Kirundi reply against corpus-backed expectations."""
+    key = config.openai_api_key()
+    context = brain_fs.collect_context(root, prompt_en or expected_hint or learner_reply)
+    if not key:
+        return (
+            "OPENAI_API_KEY missing — cannot grade automatically.\n"
+            f"Context:\n{context}\n"
+            f"Learner said: {learner_reply}"
+        )
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        return "openai package missing."
+
+    client = OpenAI(api_key=key)
+    system = (
+        "You grade Kirundi learner answers. Reply with:\n"
+        "Score: N/10\nCorrected: ...\nFeedback: ...\n"
+        "Use corpus context; be encouraging and precise."
+    )
+    user = (
+        f"Prompt (EN): {prompt_en}\n"
+        f"Expected hint: {expected_hint or '(none)'}\n"
+        f"Learner reply: {learner_reply}\n\n"
+        f"Corpus:\n{context}"
+    )
+    try:
+        completion = client.chat.completions.create(
+            model=config.openai_model(),
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            temperature=0.2,
+        )
+    except Exception as exc:
+        logger.exception("grade_answer OpenAI call failed")
+        return f"OpenAI error: {exc}"
+
+    return (completion.choices[0].message.content or "").strip()

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/requirements.txt
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/requirements.txt
@@ -1,0 +1,4 @@
+mcp>=1.0.0
+openai>=1.50.0
+openai-agents>=0.0.16
+python-dotenv>=1.0.1

--- a/6_mcp/community_contributions/Sama-ndari_kirundi-brain/server.py
+++ b/6_mcp/community_contributions/Sama-ndari_kirundi-brain/server.py
@@ -1,0 +1,155 @@
+"""
+Kirundi Study Brain MCP server (FastMCP, stdio).
+
+Local-first Markdown corpus + learner profile + grounded tutoring tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from kirundi_brain import __version__, brain_fs, config
+from kirundi_brain.profile_store import ProfileStore
+from kirundi_brain.tutor import ask_kirundi, grade_answer
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("kirundi_brain")
+
+_INSTRUCTIONS = """You back a Kirundi (Rundi) study workflow for Burundi.
+
+Use brain_* tools for Markdown under the Brain folder only (path jail).
+Use profile_* to personalize coaching.
+Use ask_kirundi for grounded Q&A (retrieve corpus, then explain).
+Use grade_kirundi_answer after short speaking/writing drills.
+
+Human-in-the-loop:
+- brain_write_markdown: overwrite=true only after learner approval.
+- brain_delete_file: user_confirmed_deletion=true only after explicit approval.
+Prefer durable lessons as .md in the Brain. Do not invent vocabulary outside tools.
+"""
+
+mcp = FastMCP(name="kirundi-study-brain", instructions=_INSTRUCTIONS)
+
+
+def _profile() -> ProfileStore:
+    return ProfileStore(config.data_dir() / "learner_profile.sqlite3")
+
+
+@mcp.tool()
+async def brain_list_files(relative_path: str = ".") -> str:
+    """List files and folders inside the Kirundi Brain corpus."""
+    return brain_fs.list_directory(config.brain_root(), relative_path)
+
+
+@mcp.tool()
+async def brain_read_file(relative_path: str) -> str:
+    """Read a Markdown/text lesson from the Kirundi Brain (relative path)."""
+    return brain_fs.read_text(config.brain_root(), relative_path)
+
+
+@mcp.tool()
+async def brain_search_notes(query: str, under_subpath: str = ".") -> str:
+    """Keyword-search .md lessons (case-insensitive) and return path + snippets."""
+    return brain_fs.search_markdown(config.brain_root(), query, under_subpath=under_subpath)
+
+
+@mcp.tool()
+async def brain_write_markdown(
+    relative_path: str,
+    content: str,
+    overwrite: bool = False,
+) -> str:
+    """Write a lesson into the Brain. Set overwrite=true only after learner approval."""
+    return brain_fs.write_markdown(
+        config.brain_root(),
+        relative_path,
+        content,
+        overwrite=overwrite,
+    )
+
+
+@mcp.tool()
+async def brain_delete_file(
+    relative_path: str,
+    user_confirmed_deletion: bool = False,
+) -> str:
+    """Delete a Brain file. Set user_confirmed_deletion=true only after explicit approval."""
+    return brain_fs.delete_file(
+        config.brain_root(),
+        relative_path,
+        confirmed=user_confirmed_deletion,
+    )
+
+
+@mcp.tool()
+async def profile_get() -> str:
+    """Return the learner profile (level, goals, recent mistakes)."""
+    return json.dumps(_profile().get(), ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def profile_update(
+    display_name: str | None = None,
+    level: str | None = None,
+    goals_json: str | None = None,
+    recent_mistakes_json: str | None = None,
+    notes: str | None = None,
+) -> str:
+    """Update learner profile fields. goals_json / recent_mistakes_json are JSON string arrays."""
+    goals = json.loads(goals_json) if goals_json else None
+    mistakes = json.loads(recent_mistakes_json) if recent_mistakes_json else None
+    if goals is not None and not isinstance(goals, list):
+        return "Error: goals_json must be a JSON array of strings."
+    if mistakes is not None and not isinstance(mistakes, list):
+        return "Error: recent_mistakes_json must be a JSON array of strings."
+    updated = _profile().update(
+        display_name=display_name,
+        level=level,
+        goals=goals,
+        recent_mistakes=mistakes,
+        notes=notes,
+    )
+    return json.dumps(updated, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def ask_kirundi_tutor(question: str) -> str:
+    """Answer a Kirundi question using Brain retrieval + optional OpenAI grounding."""
+    level = _profile().get().get("level", "A1")
+    return ask_kirundi(config.brain_root(), question, learner_level=str(level))
+
+
+@mcp.tool()
+async def grade_kirundi_answer(
+    prompt_en: str,
+    learner_reply: str,
+    expected_hint: str = "",
+) -> str:
+    """Grade a short Kirundi reply; returns score, correction, and feedback."""
+    return grade_answer(
+        config.brain_root(),
+        prompt_en=prompt_en,
+        learner_reply=learner_reply,
+        expected_hint=expected_hint,
+    )
+
+
+@mcp.tool()
+async def kirundi_brain_info() -> str:
+    """Return server version, Brain path, and data directory."""
+    info = {
+        "name": "kirundi-study-brain",
+        "version": __version__,
+        "brain_dir": str(config.brain_root()),
+        "data_dir": str(config.data_dir()),
+        "model": config.openai_model(),
+        "openai_configured": bool(config.openai_api_key()),
+    }
+    return json.dumps(info, indent=2)
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")


### PR DESCRIPTION
Local-first FastMCP corpus + profile + grounded tutor demo for Week 6.
## Summary
- FastMCP Kirundi study brain: path-jailed Markdown corpus, SQLite learner profile, grounded ask/grade tools.
- Agents SDK demo over stdio; sample lessons (greetings, courtesy, numbers, food).

## Test plan
- [x] Only `6_mcp/community_contributions/Sama-ndari_kirundi-brain/`
- [x] No `.env` / sqlite committed
- [x] `pip install -r requirements.txt` + `python demo_agent.py "..."` with key