### PR TITLE
Fix: Capture stderr in sandbox_python tool and make agent names match…

### DIFF
--- a/3_crewai/reference/engineering_team/src/engineering_team/config/agents.yaml
+++ b/3_crewai/reference/engineering_team/src/engineering_team/config/agents.yaml
@@ -1,7 +1,8 @@
 engineering_lead:
   role: >
-    Engineering Lead for the engineering team, directing the work of the engineers
+    Engineering Lead
   goal: >
+    Engineering Lead for the engineering team, directing the work of the engineers.
     You are given high level requirements for a system.
     You are responsible for designing the system to achieve the requirements, and assigning work to 3 engineers: backend_engineer, frontend_engineer, and test_engineer.
     You should describe the modules, classes, functions to be built. Give function signatures but do not write any code.
@@ -17,8 +18,9 @@ engineering_lead:
 
 backend_engineer:
   role: >
-    Python Backend Engineer who can write code to achieve the design described by the engineering lead
+    Backend Engineer
   goal: >
+    Python Backend Engineer who can write code to achieve the design described by the engineering lead.
     Use your sandbox tools to write and check python module(s) to achieve the design described by the engineering lead, in order to achieve the requirements.
     Only the Python standard library is available — do not import any third-party packages.
     Do not write any UI or frontend code; that is the frontend engineer's responsibility.
@@ -29,8 +31,9 @@ backend_engineer:
 
 frontend_engineer:
   role: >
-    A Gradio expert who can write a simple frontend to demonstrate a backend, and can validate that it will open as expected.
+    Frontend Engineer
   goal: >
+    A Gradio expert who can write a simple frontend to demonstrate a backend, and can validate that it will open as expected.
     Use your sandbox tools to write a gradio UI that demonstrates the given backend, all in one file to be in the same directory as the backend, as described in the design.
     Also write and run some python code to validate that the gradio UI constructs without error.
     Use color palette `#ecad0a` / `#209dd7` / `#753991` with grays but ensure the colors work in both light and dark mode.
@@ -43,8 +46,9 @@ frontend_engineer:
 
 test_engineer:
   role: >
-    An engineer with python coding skills who can write unit tests for the given code,
+    Test Engineer
   goal: >
+    An engineer with python coding skills who can write unit tests for the given code.
     Use your sandbox tools to write unit tests for the backend module, run them and check the results are as expected. Fix any defects and rerun the tests until they pass.
     Only the Python standard library is available — use the built-in `unittest` module. Do not use pytest or any other third-party packages.
   backstory: >

--- a/3_crewai/reference/engineering_team/src/engineering_team/tools/sandbox_tools.py
+++ b/3_crewai/reference/engineering_team/src/engineering_team/tools/sandbox_tools.py
@@ -68,27 +68,44 @@ def run_sandbox_python(filename: str) -> str:
     """
     Execute a Python file from the sandbox directory inside an ephemeral
     Docker container, with the sandbox mounted as the working directory,
-    using a uv run to run the code in the uv project,
-    and return whatever the script printed to stdout.
+    using `uv run` to run the code in the uv project.
+
+    Returns the exit code, stdout, and stderr, clearly labeled. Note that
+    Python's unittest module prints test results — including failures and
+    tracebacks — to stderr by default, not stdout, so stderr is just as
+    important as stdout for understanding what happened.
 
     Args:
         filename: The name of the Python file to run (e.g. "solution.py").
     Returns:
-        The text printed to stdout by the executed script.
+        A labeled block containing the exit code, stdout, and stderr.
     """
-    result = subprocess.run(
-        [
-            "docker", "run", "--rm",
-            "-v", f"{SANDBOX_DIR}:/workspace",
-            "-w", "/workspace",
-            "ghcr.io/astral-sh/uv:python3.13-bookworm-slim",
-            "uv", "run", filename,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    return result.stdout
+    try:
+        result = subprocess.run(
+            [
+                "docker", "run", "--rm",
+                "-v", f"{SANDBOX_DIR}:/workspace",
+                "-w", "/workspace",
+                "ghcr.io/astral-sh/uv:python3.13-bookworm-slim",
+                "uv", "run", filename,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        return (
+            f"Exit code: {result.returncode}\n\n"
+            f"--- stdout ---\n{result.stdout or '(empty)'}\n\n"
+            f"--- stderr ---\n{result.stderr or '(empty)'}"
+        )
+    except subprocess.TimeoutExpired as e:
+        stdout = e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or "")
+        stderr = e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or "")
+        return (
+            "The script timed out after 300 seconds.\n\n"
+            f"--- stdout so far ---\n{stdout or '(empty)'}\n\n"
+            f"--- stderr so far ---\n{stderr or '(empty)'}"
+        )
 
 sandbox_tools = [list_sandbox_files, read_sandbox_file, write_sandbox_file, run_sandbox_python]
 


### PR DESCRIPTION
…able

Two related bugs in the engineering_team reference implementation:

1. run_sandbox_python discarded stderr: Python's unittest module and uncaught exceptions write to stderr by default, not stdout. The tool was silently throwing away the only output that explained test failures or crashes, leaving agents unable to distinguish success from failure. Now returns exit code, stdout, and stderr clearly labeled.

2. Agent role names were unmatchable: When using hierarchical processes, delegate_to_coworker calls failed to find agents because roles used long descriptive names instead of concise titles. Updated all agent roles to match their names: backend_engineer, frontend_engineer, etc. Preserved the original role descriptions as the first line of each goal for clarity.

These fixes prevent wasted LLM calls from failed agent delegation and allow test failures to be visible to the test engineer agent.