### PR TITLE
Week 4 LangChain and LangGraph exercise solutions by Andras Nemes

### DIFF
--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/1_lab1_exercise.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/1_lab1_exercise.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Lab 1 Exercise: two tools, one loop\n",
+    "\n",
+    "This notebook solves the exercise at the end of Lab 1.\n",
+    "\n",
+    "Steps:\n",
+    "\n",
+    "1. Keep the lab's `get_share_price` tool.\n",
+    "2. Add a fake `get_exchange_rate` tool.\n",
+    "3. Bind both tools to the model.\n",
+    "4. Ask for Amazon's share price in euros.\n",
+    "5. Run the tool loop by hand until the model gives a final answer.\n",
+    "\n",
+    "The answer needs a US dollar price and a USD-to-EUR rate, so both tools must run."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "Use the lab imports. `load_dotenv` finds the `.env` file in the repository root."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langchain_core.messages import HumanMessage, ToolMessage\n",
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model\n",
+    "\n",
+    "Use the same model as the lab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = ChatOpenAI(model=\"gpt-5.4-mini\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Share price tool\n",
+    "\n",
+    "The lab tool returns a fake price, or `0.0` for an unknown symbol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def get_share_price(symbol: str) -> float:\n",
+    "    \"\"\"Return the current share price in US dollars for a given ticker symbol.\"\"\"\n",
+    "    fake_prices = {\"AAPL\": 241.5, \"GOOG\": 168.2, \"AMZN\": 198.0}\n",
+    "    return fake_prices.get(symbol.upper(), 0.0)\n",
+    "\n",
+    "print(\"name:\", get_share_price.name)\n",
+    "print(\"args:\", get_share_price.args)\n",
+    "print(\"called directly:\", get_share_price.invoke({\"symbol\": \"AMZN\"}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exchange rate tool\n",
+    "\n",
+    "The new tool returns how many units of a currency equal one US dollar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def get_exchange_rate(currency: str) -> float:\n",
+    "    \"\"\"Return how many units of the given currency equal 1 US dollar.\"\"\"\n",
+    "    fake_rates = {\"EUR\": 0.92, \"GBP\": 0.79, \"JPY\": 156.0}\n",
+    "    return fake_rates.get(currency.upper(), 1.0)\n",
+    "\n",
+    "print(\"name:\", get_exchange_rate.name)\n",
+    "print(\"args:\", get_exchange_rate.args)\n",
+    "print(\"called directly:\", get_exchange_rate.invoke({\"currency\": \"EUR\"}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bind both tools to the model\n",
+    "\n",
+    "`bind_tools` makes both tools available to the model. The reply may contain requests in `.tool_calls` instead of a final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm_with_tools = llm.bind_tools([get_share_price, get_exchange_rate])\n",
+    "\n",
+    "question = \"Use both tools to find Amazon's share price in euros.\"\n",
+    "response = llm_with_tools.invoke(question)\n",
+    "print(\"content:\", repr(response.content))\n",
+    "print(\"tool_calls:\", response.tool_calls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the tool loop by hand\n",
+    "\n",
+    "The loop:\n",
+    "\n",
+    "1. Send the conversation to the model.\n",
+    "2. Add its reply to the conversation.\n",
+    "3. Stop if the reply has no tool calls.\n",
+    "4. Run each tool and add its result as a `ToolMessage`.\n",
+    "5. Repeat.\n",
+    "\n",
+    "The name map selects the right tool. The loop allows the model to request tools in one turn or over several turns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tools_by_name = {\n",
+    "    \"get_share_price\": get_share_price,\n",
+    "    \"get_exchange_rate\": get_exchange_rate,\n",
+    "}\n",
+    "\n",
+    "conversation = [HumanMessage(question)]\n",
+    "\n",
+    "while True:\n",
+    "    ai_message = llm_with_tools.invoke(conversation)\n",
+    "    conversation.append(ai_message)\n",
+    "\n",
+    "    if not ai_message.tool_calls:\n",
+    "        break\n",
+    "\n",
+    "    for call in ai_message.tool_calls:\n",
+    "        tool_to_run = tools_by_name[call[\"name\"]]\n",
+    "        result = tool_to_run.invoke(call[\"args\"])\n",
+    "        print(f\"Ran {call['name']} with {call['args']} and got {result}\")\n",
+    "        conversation.append(ToolMessage(content=str(result), tool_call_id=call[\"id\"]))\n",
+    "\n",
+    "print(\"\\nFinal answer:\")\n",
+    "print(conversation[-1].content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "agents",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/2_lab2_exercise.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/2_lab2_exercise.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Lab 2 Exercise: three tools in a LangGraph loop\n",
+    "\n",
+    "Three tools find Stockholm's temperature, convert it to Fahrenheit, and send both values by push notification. Each step needs the last result, so the graph runs the tool loop three times."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "imports-heading",
+   "metadata": {},
+   "source": [
+    "## Imports and environment\n",
+    "\n",
+    "Add `OPENAI_API_KEY`, `SERPER_API_KEY`, `PUSHOVER_TOKEN`, and `PUSHOVER_USER` to `.env` before running the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from typing import Annotated\n",
+    "from typing_extensions import TypedDict\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Image, display\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langchain_community.tools import GoogleSerperRun\n",
+    "from langchain_community.utilities import GoogleSerperAPIWrapper\n",
+    "from langchain_core.tools import tool\n",
+    "from langgraph.graph import StateGraph, START\n",
+    "from langgraph.graph.message import add_messages\n",
+    "from langgraph.prebuilt import ToolNode, tools_condition\n",
+    "\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tools-heading",
+   "metadata": {},
+   "source": [
+    "## Three tools\n",
+    "\n",
+    "Search and push notification come from the lab. The new tool converts Celsius to Fahrenheit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tools",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search = GoogleSerperRun(api_wrapper=GoogleSerperAPIWrapper())\n",
+    "\n",
+    "@tool\n",
+    "def celsius_to_fahrenheit(celsius: float) -> float:\n",
+    "    \"\"\"Convert a temperature from degrees Celsius to degrees Fahrenheit.\"\"\"\n",
+    "    return round((celsius * 9 / 5) + 32, 1)\n",
+    "\n",
+    "@tool\n",
+    "def send_push_notification(text: str) -> str:\n",
+    "    \"\"\"Send a short push notification to the user's phone.\"\"\"\n",
+    "    requests.post(\n",
+    "        \"https://api.pushover.net/1/messages.json\",\n",
+    "        data={\n",
+    "            \"token\": os.getenv(\"PUSHOVER_TOKEN\"),\n",
+    "            \"user\": os.getenv(\"PUSHOVER_USER\"),\n",
+    "            \"message\": text,\n",
+    "        },\n",
+    "    )\n",
+    "    return \"Notification sent\"\n",
+    "\n",
+    "tools = [search, celsius_to_fahrenheit, send_push_notification]\n",
+    "\n",
+    "for available_tool in tools:\n",
+    "    print(available_tool.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "model-heading",
+   "metadata": {},
+   "source": [
+    "## Bind the tools to the model\n",
+    "\n",
+    "Bind all three tools to the model. The chatbot adds the model's reply to the graph state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = ChatOpenAI(model=\"gpt-5.4-mini\")\n",
+    "llm_with_tools = llm.bind_tools(tools)\n",
+    "\n",
+    "class State(TypedDict):\n",
+    "    messages: Annotated[list, add_messages]\n",
+    "\n",
+    "def chatbot_node(state: State) -> dict:\n",
+    "    return {\"messages\": [llm_with_tools.invoke(state[\"messages\"])]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "graph-heading",
+   "metadata": {},
+   "source": [
+    "## Build the graph\n",
+    "\n",
+    "`tools_condition` routes tool requests to `tools`. The graph then returns to `chatbot`. It stops when the model requests no tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "graph",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder = StateGraph(State)\n",
+    "builder.add_node(\"chatbot\", chatbot_node)\n",
+    "builder.add_node(\"tools\", ToolNode(tools))\n",
+    "builder.add_edge(START, \"chatbot\")\n",
+    "builder.add_conditional_edges(\"chatbot\", tools_condition)\n",
+    "builder.add_edge(\"tools\", \"chatbot\")\n",
+    "graph = builder.compile()\n",
+    "\n",
+    "display(Image(graph.get_graph().draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run and trace the graph\n",
+    "\n",
+    "Stream each graph update to show the node order, tool calls, and tool results. If LangSmith tracing is on, open this run in LangSmith and confirm the same node order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"\"\"\n",
+    "Use your tools in this exact order, waiting for the result of each tool before requesting the next one:\n",
+    "1. Search for the current temperature in Stockholm in degrees Celsius.\n",
+    "2. Pass that Celsius value to the celsius_to_fahrenheit tool.\n",
+    "3. Send a push notification containing both the Celsius and Fahrenheit temperatures.\n",
+    "After the notification is sent, give me a brief confirmation.\n",
+    "\"\"\"\n",
+    "\n",
+    "tool_request_rounds = 0\n",
+    "node_order = []\n",
+    "final_answer = \"\"\n",
+    "\n",
+    "inputs = {\"messages\": [{\"role\": \"user\", \"content\": question}]}\n",
+    "for update in graph.stream(inputs, stream_mode=\"updates\"):\n",
+    "    for node_name, node_result in update.items():\n",
+    "        node_order.append(node_name)\n",
+    "\n",
+    "        for message in node_result.get(\"messages\", []):\n",
+    "            if getattr(message, \"tool_calls\", None):\n",
+    "                tool_request_rounds += 1\n",
+    "                for call in message.tool_calls:\n",
+    "                    print(f\"AI requested {call['name']} with {call['args']}\")\n",
+    "            elif message.type == \"tool\":\n",
+    "                print(f\"Tool {message.name} returned: {message.content}\")\n",
+    "            elif node_name == \"chatbot\":\n",
+    "                final_answer = message.content\n",
+    "\n",
+    "print(\"\\nNode order:\", \" -> \".join(node_order))\n",
+    "print(f\"Tools node visits: {node_order.count('tools')}\")\n",
+    "print(f\"\\nTool-request rounds: {tool_request_rounds}\")\n",
+    "print(\"Final answer:\")\n",
+    "print(final_answer)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "agents",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/3_lab3_exercise.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/3_lab3_exercise.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Lab 3 Exercise: browser memory and a block list\n",
+    "\n",
+    "This notebook covers both tasks at the end of Lab 3.\n",
+    "\n",
+    "- Exercise 1 adds a checkpointer and `thread_id`, then checks that the agent remembers an earlier result.\n",
+    "- Exercise 2 adds middleware that blocks listed sites.\n",
+    "\n",
+    "Both tasks share the Playwright MCP browser tools."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-heading",
+   "metadata": {},
+   "source": [
+    "## Shared setup\n",
+    "\n",
+    "Load the browser tools once and use them for both tasks. They are async, so use `await` and `ainvoke`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from urllib.parse import urlparse\n",
+    "from dotenv import load_dotenv\n",
+    "from langchain.agents import create_agent\n",
+    "from langchain.agents.middleware import wrap_tool_call\n",
+    "from langchain_core.messages import ToolMessage\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "from langchain_mcp_adapters.client import MultiServerMCPClient\n",
+    "\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "win-note",
+   "metadata": {},
+   "source": [
+    "Use the lab's Windows fix for the MCP error log. It does nothing on macOS and Linux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "win-fix",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sys.platform == \"win32\":\n",
+    "    import subprocess\n",
+    "    from functools import partial\n",
+    "    import langchain_mcp_adapters.sessions as mcp_sessions\n",
+    "\n",
+    "    mcp_sessions.stdio_client = partial(mcp_sessions.stdio_client, errlog=subprocess.DEVNULL)\n",
+    "    print(\"Applied the Windows adjustment\")\n",
+    "else:\n",
+    "    print(\"Not Windows, so nothing to do here\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-tools",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = MultiServerMCPClient({\n",
+    "    \"playwright\": {\n",
+    "        \"transport\": \"stdio\",\n",
+    "        \"command\": \"npx\",\n",
+    "        \"args\": [\"-y\", \"@playwright/mcp@latest\", \"--isolated\"],\n",
+    "    }\n",
+    "})\n",
+    "\n",
+    "browser_tools = await client.get_tools()\n",
+    "print(f\"Loaded {len(browser_tools)} browser tools\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex1-heading",
+   "metadata": {},
+   "source": [
+    "## Exercise 1: browser memory\n",
+    "\n",
+    "Add `MemorySaver` and reuse one `thread_id` so the agent keeps the conversation.\n",
+    "\n",
+    "The follow-up refers to the three stories without repeating them and tells the agent not to reopen the site. A correct answer shows that memory worked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex1-turn1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "memory_browser_agent = create_agent(\n",
+    "    model=\"openai:gpt-5.5\",\n",
+    "    tools=browser_tools,\n",
+    "    system_prompt=\"You are a web research assistant. Use the browser tools to complete the task, then report clearly.\",\n",
+    "    checkpointer=MemorySaver(),\n",
+    ")\n",
+    "\n",
+    "config = {\"configurable\": {\"thread_id\": \"hn-browsing\"}}\n",
+    "\n",
+    "first = await memory_browser_agent.ainvoke(\n",
+    "    {\"messages\": [{\"role\": \"user\",\n",
+    "        \"content\": \"Go to https://news.ycombinator.com and tell me the titles of the top three stories on the front page.\"}]},\n",
+    "    config=config,\n",
+    ")\n",
+    "print(first[\"messages\"][-1].content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex1-turn2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "second = await memory_browser_agent.ainvoke(\n",
+    "    {\"messages\": [{\"role\": \"user\",\n",
+    "        \"content\": \"Of those three stories, which one sounds the most technical, and why? Do not open the site again.\"}]},\n",
+    "    config=config,\n",
+    ")\n",
+    "print(second[\"messages\"][-1].content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex2-heading",
+   "metadata": {},
+   "source": [
+    "## Exercise 2: navigation block list\n",
+    "\n",
+    "The middleware checks each navigation call. For a blocked host, it returns a `ToolMessage` without calling the handler. Other calls continue as normal.\n",
+    "\n",
+    "The browser tools are async, so the middleware awaits the handler. Only `browser_navigate` needs a host check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex2-middleware",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BLOCKED_SITES = {\"facebook.com\", \"x.com\"}\n",
+    "\n",
+    "@wrap_tool_call\n",
+    "async def block_navigation(request, handler):\n",
+    "    call = request.tool_call\n",
+    "    if call[\"name\"] == \"browser_navigate\":\n",
+    "        url = call[\"args\"].get(\"url\", \"\")\n",
+    "        host = (urlparse(url).hostname or \"\").lower().rstrip(\".\")\n",
+    "        if any(host == site or host.endswith(f\".{site}\") for site in BLOCKED_SITES):\n",
+    "            print(f\"  [blocklist] refused navigation to {url}\")\n",
+    "            return ToolMessage(\n",
+    "                content=f\"Navigation to {url} was refused: this site is on the block list.\",\n",
+    "                tool_call_id=call[\"id\"],\n",
+    "            )\n",
+    "    return await handler(request)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex2-blocked-note",
+   "metadata": {},
+   "source": [
+    "Ask the guarded agent to open a blocked site. The printed block-list message proves that the handler did not run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex2-blocked",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "guarded_agent = create_agent(\n",
+    "    model=\"openai:gpt-5.5\",\n",
+    "    tools=browser_tools,\n",
+    "    system_prompt=\"You are a web research assistant. Use the browser tools to complete the task, then report clearly.\",\n",
+    "    middleware=[block_navigation],\n",
+    ")\n",
+    "\n",
+    "blocked = await guarded_agent.ainvoke({\"messages\": [{\"role\": \"user\",\n",
+    "    \"content\": \"Go to https://www.facebook.com and tell me what you see.\"}]})\n",
+    "print(blocked[\"messages\"][-1].content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex2-allowed-note",
+   "metadata": {},
+   "source": [
+    "Now open an allowed site to show that other navigation still works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex2-allowed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "allowed = await guarded_agent.ainvoke({\"messages\": [{\"role\": \"user\",\n",
+    "    \"content\": \"Go to https://example.com and tell me the main heading on the page.\"}]})\n",
+    "print(allowed[\"messages\"][-1].content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain-langgraph-labs",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/4_lab4_exercise_part1.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/4_lab4_exercise_part1.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Lab 4 Exercise, part 1: browser tools for the research agent\n",
+    "\n",
+    "This notebook solves the main exercise at the end of Lab 4.\n",
+    "\n",
+    "The lab agent could search the web. This version also gets the Playwright MCP browser tools from Lab 3. Because those tools are async, the agent runs with `await researcher.ainvoke(...)`.\n",
+    "\n",
+    "After the run, print each file the agent created or changed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "imports-heading",
+   "metadata": {},
+   "source": [
+    "## Imports and environment\n",
+    "\n",
+    "Import the lab code, the search tool, and the MCP client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "from dotenv import load_dotenv\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langchain_community.tools import GoogleSerperRun\n",
+    "from langchain_community.utilities import GoogleSerperAPIWrapper\n",
+    "from deepagents import create_deep_agent\n",
+    "from deepagents.backends import FilesystemBackend\n",
+    "from langchain_mcp_adapters.client import MultiServerMCPClient\n",
+    "\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "win-note",
+   "metadata": {},
+   "source": [
+    "Use the Lab 3 Windows fix for the MCP error log. It does nothing on macOS and Linux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "win-fix",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sys.platform == \"win32\":\n",
+    "    import subprocess\n",
+    "    from functools import partial\n",
+    "    import langchain_mcp_adapters.sessions as mcp_sessions\n",
+    "\n",
+    "    mcp_sessions.stdio_client = partial(mcp_sessions.stdio_client, errlog=subprocess.DEVNULL)\n",
+    "    print(\"Applied the Windows adjustment\")\n",
+    "else:\n",
+    "    print(\"Not Windows, so nothing to do here\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tools-heading",
+   "metadata": {},
+   "source": [
+    "## Search and browser tools\n",
+    "\n",
+    "Keep the Serper search tool and load the Playwright browser tools with `await`. Pass them to the agent in one list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-tools",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search = GoogleSerperRun(api_wrapper=GoogleSerperAPIWrapper())\n",
+    "\n",
+    "client = MultiServerMCPClient({\n",
+    "    \"playwright\": {\n",
+    "        \"transport\": \"stdio\",\n",
+    "        \"command\": \"npx\",\n",
+    "        \"args\": [\"-y\", \"@playwright/mcp@latest\", \"--isolated\"],\n",
+    "    }\n",
+    "})\n",
+    "\n",
+    "browser_tools = await client.get_tools()\n",
+    "\n",
+    "tools = [search] + browser_tools\n",
+    "print(f\"The agent has {len(tools)} tools: search plus {len(browser_tools)} browser tools\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "agent-heading",
+   "metadata": {},
+   "source": [
+    "## Research agent\n",
+    "\n",
+    "Create the lab's Deep Agent with search and browser tools. Its prompt says when to open a search result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "build-agent",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sandbox = os.path.abspath(\"sandbox\")\n",
+    "os.makedirs(sandbox, exist_ok=True)\n",
+    "\n",
+    "model = ChatOpenAI(model=\"gpt-5.4-mini\")\n",
+    "\n",
+    "researcher = create_deep_agent(\n",
+    "    model=model,\n",
+    "    tools=tools,\n",
+    "    system_prompt=(\n",
+    "        \"You are a research analyst. Plan your work with your todo tool. \"\n",
+    "        \"Research with the search tool, and when a page is worth reading in full, \"\n",
+    "        \"open it with your browser tools. Write your findings as a tidy markdown briefing to a file.\"\n",
+    "    ),\n",
+    "    backend=FilesystemBackend(root_dir=sandbox, virtual_mode=True),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run it with ainvoke\n",
+    "\n",
+    "Use `ainvoke` because the browser tools are async. The brief requires one search fact and one fact from an opened page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "brief = \"\"\"\n",
+    "Our sales fleet is going electric and we need a short briefing on public charging in the UK.\n",
+    "Use your search tool to find roughly how many public charging points the UK has.\n",
+    "Then use your browser tool to open the website of one UK charging network and note one fact from it.\n",
+    "Write a one page markdown briefing to uk_charging.md, with a heading and a short section for each finding.\n",
+    "\"\"\"\n",
+    "\n",
+    "def file_versions(folder: str) -> dict:\n",
+    "    root = Path(folder)\n",
+    "    return {\n",
+    "        path.relative_to(root): (path.stat().st_mtime_ns, path.stat().st_size)\n",
+    "        for path in root.rglob(\"*\")\n",
+    "        if path.is_file()\n",
+    "    }\n",
+    "\n",
+    "files_before_run = file_versions(sandbox)\n",
+    "result = await researcher.ainvoke({\"messages\": [{\"role\": \"user\", \"content\": brief}]})\n",
+    "print(result[\"messages\"][-1].content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trace-heading",
+   "metadata": {},
+   "source": [
+    "## Tool calls\n",
+    "\n",
+    "The list should include planning, search, at least one `browser_` tool, and a file write."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "trace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tools_used = [tc[\"name\"] for m in result[\"messages\"] for tc in (getattr(m, \"tool_calls\", []) or [])]\n",
+    "print(\"Tools the agent called, in order:\")\n",
+    "print(tools_used)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "files-heading",
+   "metadata": {},
+   "source": [
+    "## Read files from this run\n",
+    "\n",
+    "Compare the sandbox before and after the run. Print each file the agent created or changed, and skip binary content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "read-files",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files_after_run = file_versions(sandbox)\n",
+    "written_files = [\n",
+    "    rel for rel, version in files_after_run.items()\n",
+    "    if files_before_run.get(rel) != version\n",
+    "]\n",
+    "\n",
+    "for rel in sorted(written_files):\n",
+    "    path = Path(sandbox) / rel\n",
+    "    print(f\"===== {rel} =====\")\n",
+    "    try:\n",
+    "        print(path.read_text(encoding=\"utf-8\"))\n",
+    "    except UnicodeDecodeError:\n",
+    "        print(\"(binary file, skipped)\")\n",
+    "    print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain-langgraph-labs",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/4_lab4_exercise_part2.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/4_lab4_exercise_part2.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Lab 4 Exercise, part 2: a custom slide skill\n",
+    "\n",
+    "This notebook solves the Lab 4 stretch challenge. It gives the slide-maker a Northwind Advisory house style instead of Voltway's.\n",
+    "\n",
+    "The skill lives in a folder with `SKILL.md`. The top block names and describes it, while the markdown sets the writing rules.\n",
+    "\n",
+    "The file is `sandbox/skills/northwind-slide/SKILL.md`. A sample comparison and slide tool let this notebook run on its own."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-heading",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Import the Deep Agent code and `python-pptx`. Write all files to the sandbox."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langchain_core.tools import tool\n",
+    "from deepagents import create_deep_agent\n",
+    "from deepagents.backends import FilesystemBackend\n",
+    "from pptx import Presentation\n",
+    "from pptx.dml.color import RGBColor\n",
+    "from pptx.enum.shapes import MSO_SHAPE\n",
+    "from pptx.enum.text import MSO_ANCHOR\n",
+    "from pptx.util import Inches, Pt\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "sandbox = os.path.abspath(\"sandbox\")\n",
+    "os.makedirs(sandbox, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "brief-heading",
+   "metadata": {},
+   "source": [
+    "## Sample briefing\n",
+    "\n",
+    "Write a short comparison so the notebook does not depend on an earlier agent run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "write-brief",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comparison = '''# Fleet EV comparison: Tesla Model Y vs Ford Mustang Mach-E\n",
+    "\n",
+    "## Tesla Model Y\n",
+    "- Real-world range around 330 miles\n",
+    "- Starting price around 45,000 dollars\n",
+    "- Access to the Supercharger fast charging network\n",
+    "\n",
+    "## Ford Mustang Mach-E\n",
+    "- Real-world range around 300 miles\n",
+    "- Starting price around 43,000 dollars\n",
+    "- Uses public CCS fast charging, now with Supercharger access\n",
+    "\n",
+    "## Recommendation\n",
+    "For a 100-car sales fleet, choose the Tesla Model Y for its range and charging network. The Mustang Mach-E is a close, cheaper runner-up.\n",
+    "'''\n",
+    "\n",
+    "with open(os.path.join(sandbox, \"comparison.md\"), \"w\", encoding=\"utf-8\") as f:\n",
+    "    f.write(comparison)\n",
+    "\n",
+    "print(\"Wrote comparison.md into the sandbox\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "skill-heading",
+   "metadata": {},
+   "source": [
+    "## Northwind slide skill\n",
+    "\n",
+    "The skill asks for a short claim title, three labeled points, and one clear reason for the choice. The skill controls the words; the tool controls the design.\n",
+    "\n",
+    "Read the file below. The agent later finds it through the skills folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "write-skill",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skill_path = os.path.join(sandbox, \"skills\", \"northwind-slide\", \"SKILL.md\")\n",
+    "with open(skill_path, encoding=\"utf-8\") as skill_file:\n",
+    "    print(skill_file.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tool-heading",
+   "metadata": {},
+   "source": [
+    "## Northwind slide tool\n",
+    "\n",
+    "The skill guides the words. `create_slide` applies a forest green and amber design with a Northwind footer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "slide-tool",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NORTHWIND = RGBColor(0x14, 0x3D, 0x2E)\n",
+    "AMBER = RGBColor(0xF2, 0xA6, 0x1C)\n",
+    "CREAM = RGBColor(0xF5, 0xF1, 0xE6)\n",
+    "\n",
+    "\n",
+    "def _textbox(slide, left, top, width, height, text, size, color, bold=False):\n",
+    "    box = slide.shapes.add_textbox(Inches(left), Inches(top), Inches(width), Inches(height))\n",
+    "    frame = box.text_frame\n",
+    "    frame.word_wrap = True\n",
+    "    run = frame.paragraphs[0].add_run()\n",
+    "    run.text = text\n",
+    "    run.font.size = Pt(size)\n",
+    "    run.font.color.rgb = color\n",
+    "    run.font.bold = bold\n",
+    "    return box\n",
+    "\n",
+    "\n",
+    "def build_slide(title, key_points, recommendation, outfile):\n",
+    "    prs = Presentation()\n",
+    "    prs.slide_width = Inches(13.333)\n",
+    "    prs.slide_height = Inches(7.5)\n",
+    "    slide = prs.slides.add_slide(prs.slide_layouts[6])\n",
+    "\n",
+    "    slide.background.fill.solid()\n",
+    "    slide.background.fill.fore_color.rgb = NORTHWIND\n",
+    "\n",
+    "    _textbox(slide, 0.5, 0.5, 11, 0.5, 'NORTHWIND ADVISORY  |  FLEET INTELLIGENCE', 15, AMBER, bold=True)\n",
+    "\n",
+    "    _textbox(slide, 0.5, 1.5, 12.3, 1.2, title, 34, CREAM, bold=True)\n",
+    "    rule = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.53), Inches(2.55), Inches(2.2), Inches(0.05))\n",
+    "    rule.fill.solid()\n",
+    "    rule.fill.fore_color.rgb = AMBER\n",
+    "    rule.line.fill.background()\n",
+    "\n",
+    "    for i, point in enumerate(key_points[:3]):\n",
+    "        y = 3.05 + i * 0.72\n",
+    "        marker = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(0.55), Inches(y + 0.1), Inches(0.16), Inches(0.16))\n",
+    "        marker.fill.solid()\n",
+    "        marker.fill.fore_color.rgb = AMBER\n",
+    "        marker.line.fill.background()\n",
+    "        _textbox(slide, 0.95, y, 11.8, 0.6, point, 17, CREAM)\n",
+    "\n",
+    "    _textbox(slide, 0.53, 5.55, 6, 0.4, 'NORTHWIND RECOMMENDS', 12, AMBER, bold=True)\n",
+    "    banner = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(0.5), Inches(5.95), Inches(12.33), Inches(1.05))\n",
+    "    banner.adjustments[0] = 0.18\n",
+    "    banner.fill.solid()\n",
+    "    banner.fill.fore_color.rgb = AMBER\n",
+    "    banner.line.fill.background()\n",
+    "    frame = banner.text_frame\n",
+    "    frame.word_wrap = True\n",
+    "    frame.vertical_anchor = MSO_ANCHOR.MIDDLE\n",
+    "    frame.margin_left = Inches(0.35)\n",
+    "    frame.margin_right = Inches(0.35)\n",
+    "    run = frame.paragraphs[0].add_run()\n",
+    "    run.text = recommendation\n",
+    "    run.font.size = Pt(16)\n",
+    "    run.font.bold = True\n",
+    "    run.font.color.rgb = NORTHWIND\n",
+    "\n",
+    "    prs.save(outfile)\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def create_slide(title: str, key_points: list[str], recommendation: str) -> str:\n",
+    "    \"\"\"Create a one-slide PowerPoint in the Northwind Advisory house style, saved as northwind_fleet.pptx.\"\"\"\n",
+    "    build_slide(title, key_points, recommendation, os.path.join(sandbox, \"northwind_fleet.pptx\"))\n",
+    "    return \"Saved the slide to /northwind_fleet.pptx\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "presenter-heading",
+   "metadata": {},
+   "source": [
+    "## Slide-maker and presenter\n",
+    "\n",
+    "The slide-maker gets `create_slide` and `skills=[\"/skills/\"]`. The presenter reads the comparison and sends the slide task to it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "build-presenter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slide_maker = {\n",
+    "    \"name\": \"slide-maker\",\n",
+    "    \"description\": \"Turns a finished recommendation into a one-slide PowerPoint deck.\",\n",
+    "    \"system_prompt\": \"You turn research recommendations into slides, following your northwind-slide skill.\",\n",
+    "    \"tools\": [create_slide],\n",
+    "    \"skills\": [\"/skills/\"],\n",
+    "}\n",
+    "\n",
+    "presenter = create_deep_agent(\n",
+    "    model=ChatOpenAI(model=\"gpt-5.4-mini\"),\n",
+    "    subagents=[slide_maker],\n",
+    "    system_prompt=\"You prepare research for presentation by delegating to your slide-maker sub-agent.\",\n",
+    "    backend=FilesystemBackend(root_dir=sandbox, virtual_mode=True),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-heading",
+   "metadata": {},
+   "source": [
+    "## Run it\n",
+    "\n",
+    "The presenter reads `comparison.md`. The slide-maker reads the Northwind skill and calls `create_slide`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = presenter.invoke({\"messages\": [{\"role\": \"user\", \"content\":\n",
+    "    \"Read comparison.md and have a one-slide deck made of its recommendation.\"}]})\n",
+    "print(result[\"messages\"][-1].content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "closing",
+   "metadata": {},
+   "source": [
+    "Open `northwind_fleet.pptx` in the sandbox. Change `SKILL.md` to change the writing rules, or `build_slide` to change the design."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain-langgraph-labs",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/5_lab5_exercise_part1.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/5_lab5_exercise_part1.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Lab 5 Exercise, part 1: Expedia with human approval\n",
+    "\n",
+    "This notebook solves the first part of the Lab 5 exercise: sign in to Expedia before searching for flights.\n",
+    "\n",
+    "The Lab 5 code already supports this flow:\n",
+    "\n",
+    "- `request_human_help` asks the user to take over the browser.\n",
+    "- `HumanInTheLoopMiddleware` pauses before human help or a push notification.\n",
+    "- `Sidekick.resume()` approves the pending action and continues the turn.\n",
+    "\n",
+    "The Sidekick opens Expedia and pauses at sign-in. Log in in its browser window, then resume the run. Credentials never appear in this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the lab's Windows fix for the MCP error log. It does nothing on macOS and Linux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if sys.platform == \"win32\":\n",
+    "    import subprocess\n",
+    "    from functools import partial\n",
+    "    import langchain_mcp_adapters.sessions as mcp_sessions\n",
+    "\n",
+    "    mcp_sessions.stdio_client = partial(mcp_sessions.stdio_client, errlog=subprocess.DEVNULL)\n",
+    "    print(\"Applied the Windows adjustment\")\n",
+    "else:\n",
+    "    print(\"Not Windows, so nothing to do here\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "Add the lab folder to the path and import its `Sidekick` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, os.path.abspath(os.path.join(\"..\", \"..\")))\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "import sidekick as sidekick_module\n",
+    "from sidekick import Sidekick\n",
+    "\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set the sandbox\n",
+    "\n",
+    "Point the sandbox at this contribution before `setup()`. The Sidekick creates the folder if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sandbox = os.path.abspath(\"sandbox\")\n",
+    "sidekick_module.SANDBOX = sandbox\n",
+    "\n",
+    "sidekick = Sidekick()\n",
+    "await sidekick.setup()\n",
+    "print(f\"Sidekick ready with {len(sidekick.tools)} tools\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The Expedia flight task\n",
+    "\n",
+    "Ask the Sidekick to sign in before searching. The task contains no credentials.\n",
+    "\n",
+    "The browser opens and the Sidekick should pause at the sign-in page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flight_task = \"\"\"Go to https://www.expedia.com in your browser and sign in to my Expedia account first.\n",
+    "You cannot log in yourself, so once you reach the sign-in page, ask me to do it for you.\n",
+    "Then find me the best round-trip flight from New York to London, leaving about a month from now\n",
+    "and returning a week later. I care about price first, then total journey time, and I would rather avoid\n",
+    "itineraries with two or more stops. Write your recommendation with the top three options to expedia_flights.md,\n",
+    "then send me a push notification with the price of your top pick.\"\"\"\n",
+    "\n",
+    "flight_criteria = \"\"\"The user was asked to log in to Expedia, expedia_flights.md is written with three\n",
+    "specific options including airline, times and price, plus a clear recommendation, and a push notification\n",
+    "was sent with the recommended price.\"\"\"\n",
+    "\n",
+    "history = await sidekick.run_turn(flight_task, flight_criteria, history=[])\n",
+    "print(history[-1][\"content\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## First pause: your turn at the keyboard\n",
+    "\n",
+    "Log in through the Sidekick's browser before running the next cell. Resuming approves the help request.\n",
+    "\n",
+    "A captcha or block page may appear. Complete it in the browser, then resume again if asked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = await sidekick.resume(history)\n",
+    "print(history[-1][\"content\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Approve the push notification\n",
+    "\n",
+    "After login, the Sidekick searches, writes `expedia_flights.md`, and asks before sending the push notification.\n",
+    "\n",
+    "Approve the pending action. When the run ends, the evaluator's result is the last entry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sidekick.paused:\n",
+    "    history = await sidekick.resume(history)\n",
+    "for entry in history[-2:]:\n",
+    "    print(f\"[{entry['role']}] {entry['content']}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The plan it followed\n",
+    "\n",
+    "Print `sidekick.todos` to review its plan."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for todo in sidekick.todos:\n",
+    "    print(f\"[{todo['status']}] {todo['content']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read the file it wrote\n",
+    "\n",
+    "Read the generated flight report."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print((Path(sandbox) / \"expedia_flights.md\").read_text(encoding=\"utf-8\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Close the MCP sessions and browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidekick.cleanup()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain-langgraph-labs",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/5_lab5_exercise_part2.ipynb
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/5_lab5_exercise_part2.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Lab 5 Exercise, part 2: approve file writes and add a tool\n",
+    "\n",
+    "This notebook solves the Lab 5 stretch challenge: require approval for file changes and add a new tool.\n",
+    "\n",
+    "The lab asks before push notifications and human help. This version also asks before `write_file`, `edit_file`, `create_directory`, and `move_file`. Read-only tools stay open.\n",
+    "\n",
+    "The new `@tool` currency converter uses Frankfurter's free v2 rate API. It needs no API key.\n",
+    "\n",
+    "Subclass `Sidekick` and rebuild only its worker. Keep the lab's MCP sessions, evaluator, task loop, resume flow, and cleanup."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the lab's Windows fix for the MCP error log. It does nothing on macOS and Linux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "if sys.platform == \"win32\":\n",
+    "    import subprocess\n",
+    "    from functools import partial\n",
+    "    import langchain_mcp_adapters.sessions as mcp_sessions\n",
+    "\n",
+    "    mcp_sessions.stdio_client = partial(mcp_sessions.stdio_client, errlog=subprocess.DEVNULL)\n",
+    "    print(\"Applied the Windows adjustment\")\n",
+    "else:\n",
+    "    print(\"Not Windows, so nothing to do here\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "Import `Sidekick`, its prompt, its error middleware, and the middleware used to rebuild the worker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from datetime import datetime\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, os.path.abspath(os.path.join(\"..\", \"..\")))\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "from langchain.agents import create_agent\n",
+    "from langchain.agents.middleware import (\n",
+    "    HumanInTheLoopMiddleware,\n",
+    "    ModelCallLimitMiddleware,\n",
+    "    PIIMiddleware,\n",
+    "    TodoListMiddleware,\n",
+    ")\n",
+    "from langchain_core.tools import tool\n",
+    "\n",
+    "import sidekick as sidekick_module\n",
+    "from sidekick import Sidekick, TolerateToolErrors, WORKER_PROMPT\n",
+    "\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A tool of our own: the currency converter\n",
+    "\n",
+    "Fetch one current rate from Frankfurter v2, convert the amount, and test the tool before giving it to the agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def convert_currency(amount: float, from_currency: str, to_currency: str) -> str:\n",
+    "    \"\"\"Convert an amount of money from one currency to another using current exchange rates.\n",
+    "    Use three letter currency codes such as USD, EUR or GBP.\"\"\"\n",
+    "    base = from_currency.upper()\n",
+    "    quote = to_currency.upper()\n",
+    "    response = requests.get(\n",
+    "        f\"https://api.frankfurter.dev/v2/rate/{base}/{quote}\",\n",
+    "        timeout=20,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    data = response.json()\n",
+    "    converted = round(amount * data[\"rate\"], 2)\n",
+    "    return f\"{amount:g} {base} is {converted:g} {quote} as of {data['date']}\"\n",
+    "\n",
+    "print(convert_currency.invoke({\"amount\": 100, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The subclass: a Sidekick that asks before writing\n",
+    "\n",
+    "Call the lab setup, then rebuild the worker with two changes:\n",
+    "\n",
+    "1. Add `convert_currency`.\n",
+    "2. Gate the four filesystem tools that can change files.\n",
+    "\n",
+    "Keep the rest of the middleware unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ApprovalSidekick(Sidekick):\n",
+    "    \"\"\"Add approval for file changes and a currency tool.\"\"\"\n",
+    "\n",
+    "    async def setup(self):\n",
+    "        await super().setup()\n",
+    "        self.tools = self.tools + [convert_currency]\n",
+    "        self.worker = create_agent(\n",
+    "            model=\"openai:gpt-5.4-mini\",\n",
+    "            tools=self.tools,\n",
+    "            system_prompt=f\"{WORKER_PROMPT}\\nToday is {datetime.now():%A %d %B %Y}.\",\n",
+    "            middleware=[\n",
+    "                TolerateToolErrors(),\n",
+    "                TodoListMiddleware(),\n",
+    "                PIIMiddleware(\"email\"),\n",
+    "                PIIMiddleware(\"credit_card\", apply_to_tool_results=True),\n",
+    "                ModelCallLimitMiddleware(run_limit=30),\n",
+    "                HumanInTheLoopMiddleware(\n",
+    "                    interrupt_on={\n",
+    "                        \"send_push_notification\": True,\n",
+    "                        \"request_human_help\": True,\n",
+    "                        \"write_file\": True,\n",
+    "                        \"edit_file\": True,\n",
+    "                        \"create_directory\": True,\n",
+    "                        \"move_file\": True,\n",
+    "                    }\n",
+    "                ),\n",
+    "            ],\n",
+    "            checkpointer=self.memory,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Point the sandbox at this contribution before setup. The Sidekick creates it if needed. Print the tools to confirm their names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sandbox = os.path.abspath(\"sandbox\")\n",
+    "sidekick_module.SANDBOX = sandbox\n",
+    "\n",
+    "sidekick = ApprovalSidekick()\n",
+    "await sidekick.setup()\n",
+    "print(f\"Sidekick ready with {len(sidekick.tools)} tools:\")\n",
+    "for t in sidekick.tools:\n",
+    "    print(\" -\", t.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A task that exercises both changes\n",
+    "\n",
+    "The task needs search, currency conversion, and a file write. The Sidekick should pause before writing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task = \"\"\"Use your search tool to find the current price in USD of an annual Netflix Standard subscription\n",
+    "in the United States. Convert that yearly cost to EUR with your currency tool. Then write a short markdown\n",
+    "note to price_check.md with the monthly price, the yearly cost in USD and the yearly cost in EUR.\"\"\"\n",
+    "\n",
+    "criteria = \"\"\"price_check.md is written and contains the monthly USD price, the yearly USD cost and the\n",
+    "yearly EUR cost from a real currency conversion.\"\"\"\n",
+    "\n",
+    "history = await sidekick.run_turn(task, criteria, history=[])\n",
+    "print(history[-1][\"content\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Approve the file write\n",
+    "\n",
+    "`resume()` approves the pending write. Run it again if another write needs approval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = await sidekick.resume(history)\n",
+    "print(history[-1][\"content\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sidekick.paused:\n",
+    "    history = await sidekick.resume(history)\n",
+    "for entry in history[-2:]:\n",
+    "    print(f\"[{entry['role']}] {entry['content']}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The evidence\n",
+    "\n",
+    "Print the plan and the approved file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for todo in sidekick.todos:\n",
+    "    print(f\"[{todo['status']}] {todo['content']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print((Path(sandbox) / \"price_check.md\").read_text(encoding=\"utf-8\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Close the MCP sessions and browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sidekick.cleanup()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langchain-langgraph-labs",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/4_langchain_langgraph/community_contributions/Andras_Nemes/sandbox/skills/northwind-slide/SKILL.md
+++ b/4_langchain_langgraph/community_contributions/Andras_Nemes/sandbox/skills/northwind-slide/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: northwind-slide
+description: House style for Northwind Advisory one-slide fleet recommendation decks. Use whenever a fleet recommendation needs to be turned into a PowerPoint slide.
+---
+
+# Northwind Advisory recommendation slide
+
+## When to use
+
+Use this skill when a briefing ends with a recommendation and someone asks for a slide. Create one slide, not a full deck.
+
+## House style
+
+- State the chosen vehicle in the title, such as "Recommended: Tesla Model Y". Keep it under 40 characters
+- Give exactly three key points. Start each with a one-word label and a colon, such as "Range: 330 real-world miles"
+- Write one plain sentence that names the choice and its strongest reason
+- Focus on the words. `create_slide` applies the colours, layout, and footer
+
+## Workflow
+
+1. Read the briefing or comparison
+2. Choose three key points and one recommendation sentence
+3. Call `create_slide` with the title, key points, and recommendation


### PR DESCRIPTION
## Summary

Adds my solutions for the exercises in `4_langchain_langgraph`.

## File map

- `1_lab1_exercise.ipynb`: Day 1 second tool and manual two-tool loop.
- `2_lab2_exercise.ipynb`: Day 2 third tool, repeated LangGraph tool loop, and node trace.
- `3_lab3_exercise.ipynb`: Day 3 browser memory and navigation block list.
- `4_lab4_exercise_part1.ipynb`: Day 4 main exercise, with browser tools added to the research agent.
- `4_lab4_exercise_part2.ipynb`: Day 4 stretch challenge, with a custom Northwind slide skill.
- `5_lab5_exercise_part1.ipynb`: Day 5 Expedia login with human approval.
- `5_lab5_exercise_part2.ipynb`: Day 5 "Then go further" challenge, with approved filesystem writes and a currency tool.
- `sandbox/skills/northwind-slide/SKILL.md`: Skill used by the Day 4 stretch solution. Other sandbox files are created at runtime and are not included.