### PR TITLE
My Week 1 Lab 2 community contributions (cleared outputs)

### DIFF
--- a/1_foundations/community_contributions/theo/2_lab2.ipynb
+++ b/1_foundations/community_contributions/theo/2_lab2.ipynb
@@ -1,0 +1,1076 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Welcome to the Second Lab - Week 1, Day 3\n",
+    "\n",
+    "Today we will work with lots of models! This is a way to get comfortable with APIs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left; width:100%\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../../../assets/stop.png\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#ff7800;\">Important point - please read</h2>\n",
+    "            <span style=\"color:#ff7800;\">The way I collaborate with you may be different to other courses you've taken. I prefer not to type code while you watch. Rather, I execute Jupyter Labs, like this, and give you an intuition for what's going on. My suggestion is that you carefully execute this yourself, <b>after</b> watching the lecture. Add print statements to understand what's going on, and then come up with your own variations. See Q37 in the <a href=\"https://edwarddonner.com/avatar?q=37\">FAQ</a> for how to set up a separate project for your work.<br/><br/>If you have time, I'd love it if you submit a PR for changes in the community_contributions folder - instructions in the resources. Also, if you have a Github account, use this to showcase your variations. Not only is this essential practice, but it demonstrates your skills to others, including perhaps future clients or employers...<br/>And if you post about it on LinkedIn and tag me, then I'll weigh in to amplify your achievement. If you see other students posting, please give them your encouragement too.\n",
+    "            </span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Community contribution — Lab 2 (from week 1, day 3)\n",
+    "\n",
+    "My contribution consist of three sets of changes. (Per Python's PEP-8 I hope my code is somewhat clear and readable enough that it does not need heavy commenting, fingers crossed).\n",
+    "\n",
+    "Just for the sake of the exercise, I didn't ask any LLM to create the code or come up with the idea, so I could put just some thought to it.\n",
+    "\n",
+    "### 1. To the Original lab \n",
+    "\n",
+    "- Import and use the official SDKs for Anthropic, Google, Groq, xAI, OpenRouter, and Ollama, so it can be compared side by side in the same cells.\n",
+    "- I added the shared `record()` helper in the Groq and Ollama cells replacing the `display` / `append` separate calls in those cells (so all the models use the record() function).\n",
+    "\n",
+    "### 2. Improved workflow\n",
+    "\n",
+    "This section starts after the original lab cells.. It follows the lecture prompt from Ed to try to make the workflow more sophisticated. I aimed to use only the content from the course so far and what Ed included in all the GitHub guides (e.g. Python's async), and to keep the workflow, so the essence is still there.\n",
+    "\n",
+    "- I created dicts for the LLM providers/models, so parallel runs with async are easier to manage and extra per-model settings and/or more models/providers can be added later.\n",
+    "\n",
+    "- Added to the judge prompt XML tags around the question, format, and responses. I read some time ago on Claude’s prompting guidance and related papers on structured prompts that this helps the LLM to understand the structure and in general is a good practice (arXiv papers 2510.22956, 2509.08182).\n",
+    "\n",
+    "- Also I added a prompt dict, easier management of prompt templates, and in the case of the judge, it could be filled for the particular call with the `str.format()` method.\n",
+    "\n",
+    "- New function helpers (including API-key prefix printing).\n",
+    "\n",
+    "- To be faithful to the original lab, `llm_call()` keeps Ed’s `reasoning_effort=\"none\"` behavior for `gpt-5.4-nano` , it works from a conditional.\n",
+    "\n",
+    "- The async function llm_call is a starting point: it can be modified to expand/add conditions/features, for example: skip disabled models (e.g. in the LLMs dict with an \"disabled\" property), pull `max_tokens` / `reasoning_effort` (it could be from the prompts dict), etc, switch SDKs (I coded this new section to use the OpenAISDK. As recreating an improved version of the original lab code.)\n",
+    "\n",
+    "### 3. Additional agentic design pattern\n",
+    "\n",
+    "- I added an additional agentic workflow design pattern at the end, as an example to start a version 3 of the code of this lab (v1 the original, v2 the improved workflow, v3 adding additional patterns or calls asking new things). The added pattern is **routing**. \n",
+    "\n",
+    "It works this way:\n",
+    "\n",
+    "1. Models vote using the agentic workflow parallel design pattern on which model should write the opening question (an LLM council).\n",
+    "2. Votes are counted. On a tie, `max()` keeps the first model that reached that count. (This could be changed but for the moment let's say it's \"destiny\").\n",
+    "3. That code routes the question-generation prompt to the winner model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start with imports - ask the Cursor Agent to explain any package that you don't know\n",
+    "\n",
+    "import os\n",
+    "import json\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from anthropic import Anthropic\n",
+    "from google import genai\n",
+    "from groq import Groq\n",
+    "from xai_sdk import Client as grok_client\n",
+    "from xai_sdk.chat import user as grok_user\n",
+    "from openrouter import OpenRouter\n",
+    "from ollama import Client as ollama_chat\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Always remember to do this!\n",
+    "load_dotenv(override=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print the key prefixes to help with any debugging\n",
+    "\n",
+    "openai_api_key = os.getenv('OPENAI_API_KEY')\n",
+    "anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')\n",
+    "google_api_key = os.getenv('GOOGLE_API_KEY')\n",
+    "deepseek_api_key = os.getenv('DEEPSEEK_API_KEY')\n",
+    "groq_api_key = os.getenv('GROQ_API_KEY')\n",
+    "grok_api_key = os.getenv('GROK_API_KEY')\n",
+    "openrouter_api_key = os.getenv('OPENROUTER_API_KEY')\n",
+    "\n",
+    "if openai_api_key:\n",
+    "    print(f\"OpenAI API Key exists and begins {openai_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"OpenAI API Key not set\")\n",
+    "    \n",
+    "if anthropic_api_key:\n",
+    "    print(f\"Anthropic API Key exists and begins {anthropic_api_key[:7]}\")\n",
+    "else:\n",
+    "    print(\"Anthropic API Key not set (and this is optional)\")\n",
+    "\n",
+    "if google_api_key:\n",
+    "    print(f\"Google API Key exists and begins {google_api_key[:2]}\")\n",
+    "else:\n",
+    "    print(\"Google API Key not set (and this is optional)\")\n",
+    "\n",
+    "if deepseek_api_key:\n",
+    "    print(f\"DeepSeek API Key exists and begins {deepseek_api_key[:3]}\")\n",
+    "else:\n",
+    "    print(\"DeepSeek API Key not set (and this is optional)\")\n",
+    "\n",
+    "if groq_api_key:\n",
+    "    print(f\"Groq API Key exists and begins {groq_api_key[:4]}\")\n",
+    "else:\n",
+    "    print(\"Groq API Key not set (and this is optional)\")\n",
+    "\n",
+    "if grok_api_key:\n",
+    "    print(f\"Grok API Key exists and begins {grok_api_key[:4]}\")\n",
+    "else:\n",
+    "    print(\"Grok API Key not set (and this is optional)\")\n",
+    "\n",
+    "if openrouter_api_key:\n",
+    "    print(f\"OpenRouter API Key exists and begins {openrouter_api_key[:6]}\") \n",
+    "else:\n",
+    "    print(\"OpenRouter API Key not set (and this is optional)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "request = \"\"\"\n",
+    "Please come up with a challenging, nuanced question with a succinct answer,\n",
+    "that I can ask a number of LLMs to evaluate their intelligence.\n",
+    "Not a mathematical puzzle, but more of a thought-provoking question that requires intelligent insight.\n",
+    "Include in your question that the answer must be short.\n",
+    "\"\"\"\n",
+    "request += \"Answer only with the question, no explanation.\"\n",
+    "messages = [{\"role\": \"user\", \"content\": request}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openai = OpenAI()\n",
+    "\n",
+    "response = openai.chat.completions.create(model=\"gpt-5.4-mini\", messages=messages)\n",
+    "question = response.choices[0].message.content\n",
+    "display(Markdown(question))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calling LLMs from multiple providers\n",
+    "\n",
+    "We are about to call LLMs from many other providers.\n",
+    "They all provide API endpoints that are compatible with OpenAI, as explained in Guide 9 in the guides folder.\n",
+    "So we can simply use these endpoints as if we are using OpenAI.\n",
+    "\n",
+    "Please note:\n",
+    "\n",
+    "I'm going to use lots of LLMs from different providers, but you don't need to! This is only to show their abilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OpenAI Compatible URLs\n",
+    "\n",
+    "ANTHROPIC_BASE_URL = \"https://api.anthropic.com/v1/\"\n",
+    "DEEPSEEK_BASE_URL = \"https://api.deepseek.com/v1\"\n",
+    "GEMINI_BASE_URL = \"https://generativelanguage.googleapis.com/v1beta/openai/\"\n",
+    "GROQ_BASE_URL = \"https://api.groq.com/openai/v1\"\n",
+    "GROK_BASE_URL = \"https://api.x.ai/v1\"\n",
+    "OPENROUTER_BASE_URL = \"https://openrouter.ai/api/v1\"\n",
+    "OLLAMA_BASE_URL = \"http://localhost:11434/v1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OpenAI client libraries with the right base_url and key\n",
+    "# If this surprises you, please see Guide 9 in the Guides folder!\n",
+    "\n",
+    "anthropic = OpenAI(api_key=anthropic_api_key, base_url=ANTHROPIC_BASE_URL)\n",
+    "deepseek = OpenAI(api_key=deepseek_api_key, base_url=DEEPSEEK_BASE_URL)\n",
+    "gemini = OpenAI(api_key=google_api_key, base_url=GEMINI_BASE_URL)\n",
+    "groq = OpenAI(api_key=groq_api_key, base_url=GROQ_BASE_URL)\n",
+    "grok = OpenAI(api_key=grok_api_key, base_url=GROK_BASE_URL)\n",
+    "openrouter = OpenAI(api_key=openrouter_api_key, base_url=OPENROUTER_BASE_URL)\n",
+    "ollama = OpenAI(base_url=OLLAMA_BASE_URL, api_key=\"ollama\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "competitors = []\n",
+    "answers = []\n",
+    "messages = [{\"role\": \"user\", \"content\": question}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def record(model_name, answer):\n",
+    "    competitors.append(model_name)\n",
+    "    answers.append(answer)\n",
+    "    display(Markdown(answer))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The API we know well\n",
+    "# Reasoning effort can be none, low, medium, high, or xhigh\n",
+    "\n",
+    "model_name = \"gpt-5.4-nano\"\n",
+    "\n",
+    "response = openai.chat.completions.create(model=model_name, messages=messages, reasoning_effort=\"none\")\n",
+    "answer = response.choices[0].message.content\n",
+    "\n",
+    "record(model_name, answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Anthropic\n",
+    "\n",
+    "model_name = \"claude-sonnet-4-6\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = anthropic.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via Anthropic SDK\n",
+    "anthropic_api_call = Anthropic()\n",
+    "response = anthropic_api_call.messages.create(model=model_name, messages=messages, max_tokens=1024)\n",
+    "answer = response.content[0].text\n",
+    "\n",
+    "record(model_name, answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Gemini\n",
+    "\n",
+    "model_name = \"gemini-3.1-flash-lite\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = gemini.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via Google SDK\n",
+    "gemini_sdk_call = genai.Client()\n",
+    "response = gemini_sdk_call.interactions.create(model=model_name, input=question)\n",
+    "answer = response.output_text\n",
+    "\n",
+    "record(model_name, answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DeepSeek\n",
+    "# DeepSeek has no official Python SDK, so using the OpenAI compatible client.\n",
+    "\n",
+    "model_name = \"deepseek-v4-flash\"\n",
+    "\n",
+    "response = deepseek.chat.completions.create(model=model_name, messages=messages)\n",
+    "answer = response.choices[0].message.content\n",
+    "\n",
+    "record(model_name, answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Groq\n",
+    "\n",
+    "model_name = \"openai/gpt-oss-120b\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = groq.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via Groq SDK\n",
+    "groq_sdk_call = Groq()\n",
+    "response = groq_sdk_call.chat.completions.create(model=model_name, messages=messages)\n",
+    "answer = response.choices[0].message.content\n",
+    "\n",
+    "record(f\"Groq - {model_name}\", answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OpenRouter\n",
+    "\n",
+    "model_name = \"moonshotai/kimi-k2.6\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = openrouter.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via OpenRouter SDK\n",
+    "openrouter_sdk_call = OpenRouter(api_key=openrouter_api_key)\n",
+    "response = openrouter_sdk_call.chat.send(model=model_name, messages=messages)\n",
+    "answer = response.choices[0].message.content\n",
+    "\n",
+    "record(f\"OpenRouter - {model_name}\", answer)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## For the next cell, we will use Ollama\n",
+    "\n",
+    "Ollama runs a local web service that gives an OpenAI compatible endpoint,  \n",
+    "and runs models locally using high performance C++ code.\n",
+    "\n",
+    "If you don't have Ollama, install it here by visiting https://ollama.com then pressing Download and following the instructions.\n",
+    "\n",
+    "After it's installed, you should be able to visit here: http://localhost:11434 and see the message \"Ollama is running\"\n",
+    "\n",
+    "You might need to restart Cursor (and maybe reboot). Then open a Terminal (control+\\`) and run `ollama serve`\n",
+    "\n",
+    "Useful Ollama commands (run these in the terminal, or with an exclamation mark in this notebook):\n",
+    "\n",
+    "`ollama pull <model_name>` downloads a model locally  \n",
+    "`ollama ls` lists all the models you've downloaded  \n",
+    "`ollama rm <model_name>` deletes the specified model from your downloads"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left; width:100%\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../../../assets/stop.png\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#ff7800;\">Super important - ignore me at your peril!</h2>\n",
+    "            <span style=\"color:#ff7800;\">Many models on Ollama are FAR too large for your home computer. Be sure to browse the models on the Ollama website. Look to use models that are size 3GB or less unless you know better; llama3.2 is a great first choice. Don't pick models that end in :cloud; that's something different (a cloud inference service, like Groq).\n",
+    "            </span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ollama pull llama3.2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "requests.get('http://localhost:11434').content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "models = requests.get('http://localhost:11434/v1/models').json()\n",
+    "for model in models.get(\"data\"):\n",
+    "    print(model.get(\"id\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Local Ollama - Llama3.2:1b\n",
+    "\n",
+    "model_name = \"llama3.2:1b\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = ollama.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via Ollama SDK\n",
+    "ollama_sdk_call = ollama_chat()\n",
+    "response = ollama_sdk_call.chat(model=model_name, messages=messages)\n",
+    "answer = response.message.content\n",
+    "\n",
+    "record(f\"Local Ollama: {model_name}\", answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Local Ollama - gpt-oss:latest\n",
+    "\n",
+    "model_name = \"gpt-oss:latest\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = ollama.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via Ollama SDK\n",
+    "response = ollama_sdk_call.chat(model=model_name, messages=messages)\n",
+    "answer = response.message.content\n",
+    "\n",
+    "record(f\"Local Ollama: {model_name}\", answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Local Ollama - gemma4:latest\n",
+    "\n",
+    "model_name = \"gemma4:latest\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = ollama.chat.completions.create(model=model_name, messages=messages)\n",
+    "# answer = response.choices[0].message.content\n",
+    "\n",
+    "# via Ollama SDK\n",
+    "response = ollama_sdk_call.chat(model=model_name, messages=messages)\n",
+    "answer = response.message.content\n",
+    "\n",
+    "record(f\"Local Ollama: {model_name}\", answer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# So where are we?\n",
+    "\n",
+    "print(len(competitors))\n",
+    "print(competitors)\n",
+    "print(answers)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It's nice to know how to use \"zip\"\n",
+    "for competitor, answer in zip(competitors, answers):\n",
+    "    print(f\"Competitor: {competitor}\\n\\n{answer}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's bring this together - note the use of \"enumerate\"\n",
+    "\n",
+    "together = \"\"\n",
+    "for index, answer in enumerate(answers):\n",
+    "    together += f\"# Response from competitor {index+1}\\n\\n\"\n",
+    "    together += answer + \"\\n\\n\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(together)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judge = f\"\"\"You are judging a competition between {len(competitors)} competitors.\n",
+    "Each model has been given this question:\n",
+    "\n",
+    "<question>\n",
+    "{question}\n",
+    "</question>\n",
+    "\n",
+    "Your job is to evaluate each response for clarity and strength of argument, and rank them in order of best to worst.\n",
+    "Respond with JSON, and only JSON, with the following format:\n",
+    "<format>\n",
+    "{{\"results\": [\"best competitor number\", \"second best competitor number\", \"third best competitor number\", ...]}}\n",
+    "</format>\n",
+    "\n",
+    "Here are the responses from each competitor:\n",
+    "\n",
+    "<responses>\n",
+    "{together}\n",
+    "</responses>\n",
+    "\n",
+    "Now respond with the JSON with the ranked order of the competitors, nothing else. Do not include markdown formatting or code blocks.\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(judge)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "judge_messages = [{\"role\": \"user\", \"content\": judge}]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## And now for Grok!\n",
+    "\n",
+    "Branded as \"The most truth-seeking large language model in the world\".. so let's use it as our LLM as a judge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Judgement time!\n",
+    "# Grok is \"The most truth-seeking large language model in the world.\"\n",
+    "\n",
+    "model_name = \"grok-4.3\"\n",
+    "\n",
+    "# via OpenAI SDK compatibility\n",
+    "# response = grok.chat.completions.create(model=model_name, messages=judge_messages)\n",
+    "# results = response.choices[0].message.content\n",
+    "# print(results)\n",
+    "\n",
+    "# via Grok SDK\n",
+    "grok_sdk_call = grok_client()\n",
+    "response = grok_sdk_call.chat.create(model=model_name).append(grok_user(judge))\n",
+    "results = response.sample().content\n",
+    "print(results)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OK let's turn this into results!\n",
+    "\n",
+    "results_dict = json.loads(results)\n",
+    "ranks = results_dict[\"results\"]\n",
+    "for index, result in enumerate(ranks):\n",
+    "    competitor = competitors[int(result)-1]\n",
+    "    print(f\"Rank {index+1}: {competitor}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left; width:100%\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../../../assets/exercise.png\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#ff7800;\">Exercise</h2>\n",
+    "            <span style=\"color:#ff7800;\">Which pattern(s) did this use? Try updating this to add another Agentic design pattern.\n",
+    "            </span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Answer: Patterns this used: a combination of **prompt chaining**  and **parallelization**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import asyncio\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import AsyncOpenAI\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "\n",
+    "llms_list = {\n",
+    "    \"OpenAI\": {\n",
+    "        \"models\": [\"gpt-5.4-nano\"],\n",
+    "        \"api_base_url\": \"\",\n",
+    "        \"api_key\": os.getenv('OPENAI_API_KEY'),\n",
+    "        \"safe_key_reveal\": 8\n",
+    "    },\n",
+    "    \"Anthropic\": {\n",
+    "        \"models\": [\"claude-sonnet-4-6\"],\n",
+    "        \"api_base_url\": \"https://api.anthropic.com/v1/\",\n",
+    "        \"api_key\": os.getenv('ANTHROPIC_API_KEY'),\n",
+    "        \"safe_key_reveal\": 7\n",
+    "    },\n",
+    "    \"Google\": {\n",
+    "        \"models\": [\"gemini-3.1-flash-lite\"],\n",
+    "        \"api_base_url\": \"https://generativelanguage.googleapis.com/v1beta/openai/\",\n",
+    "        \"api_key\": os.getenv('GOOGLE_API_KEY'),\n",
+    "        \"safe_key_reveal\": 2\n",
+    "    },\n",
+    "    \"DeepSeek\": {\n",
+    "        \"models\": [\"deepseek-v4-flash\"],\n",
+    "        \"api_base_url\": \"https://api.deepseek.com/v1\",\n",
+    "        \"api_key\": os.getenv('DEEPSEEK_API_KEY'),\n",
+    "        \"safe_key_reveal\": 3\n",
+    "    },\n",
+    "    \"Groq\": {\n",
+    "        \"models\": [\"openai/gpt-oss-120b\"],\n",
+    "        \"api_base_url\": \"https://api.groq.com/openai/v1\",\n",
+    "        \"api_key\": os.getenv('GROQ_API_KEY'),\n",
+    "        \"safe_key_reveal\": 4\n",
+    "    },\n",
+    "    \"OpenRouter\": {\n",
+    "        \"models\": [\"moonshotai/kimi-k2.6\"],\n",
+    "        \"api_base_url\": \"https://openrouter.ai/api/v1\",\n",
+    "        \"api_key\": os.getenv('OPENROUTER_API_KEY'),\n",
+    "        \"safe_key_reveal\": 6\n",
+    "    },\n",
+    "    \"Local Ollama\": {\n",
+    "        \"models\": [\"llama3.2:1b\", \"gemma4:latest\", \"gpt-oss:latest\"],\n",
+    "        \"api_base_url\": \"http://localhost:11434/v1\",\n",
+    "        \"api_key\": \"ollama\",\n",
+    "        \"safe_key_reveal\": 2\n",
+    "    },\n",
+    "    \"Grok\": {\n",
+    "        \"models\": [\"grok-4.3\"],\n",
+    "        \"api_base_url\": \"https://api.x.ai/v1\",\n",
+    "        \"api_key\": os.getenv('GROK_API_KEY'),\n",
+    "        \"safe_key_reveal\": 4\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "\n",
+    "# Print the key prefixes to help with any debugging\n",
+    "for llm_provider, provider_details in llms_list.items():\n",
+    "    print(f\"{llm_provider} API Key\", end=\" \")\n",
+    "    if provider_details.get(\"api_key\"):\n",
+    "        print(f\"exists and begins {provider_details.get(\"api_key\")[:provider_details.get(\"safe_key_reveal\")]}\")\n",
+    "    else:\n",
+    "        print(f\"not set{\" (and this is optional)\" if llm_provider != \"OpenAI\" else \"\"}\")\n",
+    "        \n",
+    "\n",
+    "lab2_default_prompts = {\n",
+    "    \"initial_question\": \"\"\"\n",
+    "                  Please come up with a challenging, nuanced question with a succinct answer,\n",
+    "that I can ask a number of LLMs to evaluate their intelligence.\n",
+    "Not a mathematical puzzle, but more of a thought-provoking question that requires intelligent insight.\n",
+    "Include in your question that the answer must be short.\n",
+    "                 Answer only with the question, no explanation.\n",
+    "                        \"\"\",\n",
+    "    \"judge\": \"\"\"\n",
+    "                You are judging a competition between {len_competitors} competitors.\n",
+    "Each model has been given this question:\n",
+    "\n",
+    "<question>\n",
+    "{question}\n",
+    "</question>\n",
+    "\n",
+    "Your job is to evaluate each response for clarity and strength of argument, and rank them in order of best to worst.\n",
+    "Respond with JSON, and only JSON, with the following format:\n",
+    "<format>\n",
+    "{{\"results\": [\"best competitor number\", \"second best competitor number\", \"third best competitor number\", ...]}}\n",
+    "</format>\n",
+    "\n",
+    "Here are the responses from each competitor:\n",
+    "\n",
+    "<responses>\n",
+    "{together}\n",
+    "</responses>\n",
+    "\n",
+    "Now respond with the JSON with the ranked order of the competitors, nothing else. Do not include markdown formatting or code blocks.\n",
+    "            \"\"\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "competitors = []\n",
+    "answers = []\n",
+    "\n",
+    "\n",
+    "async def record(provider_n_model_name: str, answer: str, print_answer: bool):\n",
+    "    competitors.append(provider_n_model_name)\n",
+    "    answers.append(answer)\n",
+    "    if print_answer:\n",
+    "        display(Markdown(f\"{provider_n_model_name} answer: {answer}\"))\n",
+    "\n",
+    "\n",
+    "async def llm_call(models_to_call: str | tuple, prompt: str):\n",
+    "    single_model = True if isinstance(models_to_call, tuple) else False\n",
+    "\n",
+    "    provider = models_to_call[0] if single_model else models_to_call\n",
+    "    models_list = [models_to_call[1]] if single_model else llms_list.get(provider).get(\"models\")\n",
+    "\n",
+    "    openai_sdk_async_client = AsyncOpenAI() if provider == \"OpenAI\" else AsyncOpenAI(api_key=llms_list.get(provider).get(\"api_key\"), base_url=llms_list.get(provider).get(\"api_base_url\"))\n",
+    "    \n",
+    "    for model in models_list:\n",
+    "        # Random colour for the provider/model name so parallel async logs are easier to scan. The color index is chosen to stay readable on dark and light backgrounds\n",
+    "        prov_mod_colour = f\"\\033[38;5;{82+sum(map(ord, model))%150}m{provider} - {model}\\033[0m\"\n",
+    "        try:\n",
+    "            print(\"\\x1B[3m\" + \"Sending request/prompt to: \"+ \"\\x1B[0m\" + f\"{prov_mod_colour}\")\n",
+    "            response = await openai_sdk_async_client.chat.completions.create(model=model, messages=[{\"role\": \"user\", \"content\": prompt}], **({\"reasoning_effort\": \"none\"} if model == \"gpt-5.4-nano\" else {}))\n",
+    "            answer = response.choices[0].message.content\n",
+    "        except Exception as e:\n",
+    "            print(f\"Error from {prov_mod_colour}: {e}\")\n",
+    "        else:\n",
+    "            print(f\"{prov_mod_colour} \" + \"\\033[4m\" + \"response received.\" + \"\\033[0m\")\n",
+    "            if single_model:\n",
+    "                return answer\n",
+    "            else:\n",
+    "                await record(f\"{provider}: {model}\", answer, False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = await llm_call((\"OpenAI\", \"gpt-5.4-mini\"), lab2_default_prompts.get(\"initial_question\"))\n",
+    "display(Markdown(question))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parallelization, as in the previous section, but with async\n",
+    "llms_in_parallel = [llm_call(provider, question) for provider in llms_list.keys() if provider != \"Grok\"]\n",
+    "results = await asyncio.gather(*llms_in_parallel)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# So where are we?\n",
+    "\n",
+    "print(len(competitors))\n",
+    "print(competitors)\n",
+    "print(answers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It's nice to know how to use \"zip\"\n",
+    "for competitor, answer in zip(competitors, answers):\n",
+    "    print(f\"Competitor: {competitor}\\n\\n{answer}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's bring this together - note the use of \"enumerate\"\n",
+    "\n",
+    "together = \"\"\n",
+    "for index, answer in enumerate(answers):\n",
+    "    together += f\"# Response from competitor {index+1}\\n\\n\"\n",
+    "    together += answer + \"\\n\\n\"\n",
+    "\n",
+    "print(together)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Judgement time!\n",
+    "# Grok is \"The most truth-seeking large language model in the world.\"\n",
+    "\n",
+    "results = await llm_call((\"Grok\", \"grok-4.3\"), lab2_default_prompts.get(\"judge\").format(len_competitors=len(competitors), question=question, together=together))\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OK let's turn this into results!\n",
+    "\n",
+    "results_dict = json.loads(results)\n",
+    "ranks = results_dict[\"results\"]\n",
+    "for index, result in enumerate(ranks):\n",
+    "    competitor = competitors[int(result)-1]\n",
+    "    print(f\"Rank {index+1}: {competitor}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now adding another Agentic Workflow Design Pattern\n",
+    "\n",
+    "#### Routing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# I know there is some inconsistency in the type hits in my code here, as I added some type hints to some variables/functions and not to others like outputs. For this exercise I mostly annotated function parameters where I think it helps with clarification\n",
+    "\n",
+    "list_of_models = [model for provider in llms_list.values() for model in provider.get(\"models\", [])]\n",
+    "\n",
+    "# I added the \"```json\" instruction because it happened a few times when I was testing the approach, especially from the local models\n",
+    "llm_council_prompt = f\"\"\"\n",
+    "As of today, 31 August 2026, choose which model from this list is best suited to write \"a challenging, nuanced question with a short answer, which will then be used to compare several LLMs. The question should be thought-provoking, not a math puzzle.\"\n",
+    "\n",
+    "<list_of_models>{\", \".join(list_of_models)}</list_of_models>\n",
+    "\n",
+    "Reply with JSON only, in exactly this shape:\n",
+    "{{\"model_selected\": \"the model you selected\", \"reason\": \"one sentence\"}}\n",
+    "\n",
+    "Don't answer the question itself. Exclude from the output any chain-of-thought information or steps you did. No markdown, no code fences, no extra braces. Don't prefix the output with the following characters: ```json\n",
+    "\"\"\"\n",
+    "\n",
+    "previous_competitors = competitors.copy()\n",
+    "previous_answers = answers.copy()\n",
+    "\n",
+    "competitors = []\n",
+    "answers = []\n",
+    "\n",
+    "\n",
+    "llms_in_parallel = [llm_call(provider, llm_council_prompt) for provider in llms_list.keys()]\n",
+    "await asyncio.gather(*llms_in_parallel)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for competitor, answer in zip(competitors, answers):\n",
+    "    print(f\"------\\n-Competitor: {competitor}\\n-Answer: {answer}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vote_results = []\n",
+    "winner = \"\"\n",
+    "\n",
+    "# I thought of using json.JSONDecoder().raw_decode() because in a few occasions the Local LLM returned an extra character, like }}.\n",
+    "# But then I considered there are a few other verifications that could be done, so I decided to go for a try/except\n",
+    "for index, llm_voter_answer in enumerate(answers):\n",
+    "    try:\n",
+    "        vote = json.loads(llm_voter_answer).get(\"model_selected\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"|----\\n-Could not parse the vote from - {competitors[index]}\\n-Answer: {answers[index]}\\n-Error: {e} \\n\")\n",
+    "    else:\n",
+    "        vote_results.append(vote)\n",
+    "\n",
+    "\n",
+    "winner = max(set(vote_results), key=vote_results.count)\n",
+    "print(f\"From the LLM Council, the model selected for the next task is: {winner}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_provider(model_name: str):\n",
+    "    return next((provider for provider, provider_details in llms_list.items() if model_name in provider_details.get(\"models\", [])), None)\n",
+    "\n",
+    "\n",
+    "question = await llm_call((get_provider(winner), winner), lab2_default_prompts.get(\"initial_question\"))\n",
+    "display(Markdown(question))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Other ideas I considered for adding another agentic workflow design pattern:\n",
+    "    - Same routing idea, but vote on which model should be the judge, and why.\n",
+    "    - \"Prompt chaining\" so a random model is selected to write the initial question and another random model is selected as the judge prompt. Then adding the \"Evaluator-Optimizer\" so the others LLMs act as evaluators and accept or reject the proposed question.\n",
+    "    - Ask the models, using Anthropic’s pattern definitions, which extra agentic workflow design pattern they would add and why, then implement that choice with \"Orchestrator–Workers\" design pattern.\n",
+    "    - Ask the models to vote on call order by latency (fastest API first). Even if it only saves milliseconds, I think it is an interesting experiment.\n",
+    "    - Just for fun and comparison, for one or two models, call the HTTP API directly with the `requests` library (`POST`, `GET`, and so on)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left; width:100%\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../../../assets/business.png\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#00bfff;\">Commercial implications</h2>\n",
+    "            <span style=\"color:#00bfff;\">These kinds of patterns - to send a task to multiple models, and evaluate results,\n",
+    "            are common where you need to improve the quality of your LLM response. This approach can be universally applied\n",
+    "            to business projects where accuracy is critical.\n",
+    "            </span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi Ed!  Hope you are doing very well! In advance, thank you for your time. 

Comments below also in the .ipynb file for anyone else who would like to understand what I did in this community contribution:

---
My contribution consist of three sets of changes. (Per Python's PEP-8 I hope my code is somewhat clear and readable enough that it does not need heavy commenting, fingers crossed).

Just for the sake of the exercise, I didn't ask any LLM to create the code or come up with the idea, so I could put just some thought to it.

### 1. To the Original lab 

- Import and use the official SDKs for Anthropic, Google, Groq, xAI, OpenRouter, and Ollama, so it can be compared side by side in the same cells.
- I added the shared `record()` helper in the Groq and Ollama cells replacing the `display` / `append` separate calls in those cells (so all the models use the record() function).

### 2. Improved workflow

This section starts after the original lab cells. It follows the lecture prompt from Ed to try to make the workflow more sophisticated. I aimed to use only the content from the course so far and what Ed included in all the GitHub guides (e.g. Python's async), and to keep the workflow, so the essence is still there.

- I created a dict for the LLM providers/models, so parallel runs with async are easier to manage and extra per-model settings and/or more models/providers can be added later.

- Added to the judge prompt XML tags around the question, format, and responses. I read some time ago on Claude’s prompting guidance and related papers on structured prompts that this helps the LLM to understand the structure and in general is a good practice (arXiv papers 2510.22956, 2509.08182).

- Also I added a prompt dict, easier management of prompt templates, and in the case of the judge, it could be filled for the particular call with the `str.format()` method.

- New function helpers (including API-key prefix printing).

- To be faithful to the original lab, `llm_call()` keeps Ed’s `reasoning_effort="none"` behavior for `gpt-5.4-nano` , it works from a conditional.

- The async function llm_call is a starting point: it can be modified to expand/add conditions/features, for example: skip disabled models (e.g. in the LLMs dict with an "disabled" property), pull `max_tokens` / `reasoning_effort` (it could be from the prompts dict), etc, switch SDKs (I coded this new section to use the OpenAISDK. As recreating an improved version of the original lab code.)

### 3. Additional agentic design pattern

- I added an additional agentic workflow design pattern at the end, as an example to start a version 3 of the code of this lab (v1 the original, v2 the improved workflow, v3 adding additional patterns or calls asking new things). The added pattern is **routing**. 

It works this way:

1. Models vote using the agentic workflow parallel design pattern on which model should write the opening question (an LLM council).
2. Votes are counted. On a tie, `max()` keeps the first model that reached that count. (This could be changed but for the moment let's say it's "destiny").
3. That code routes the question-generation prompt to the winner model.
----

Kind Regards,

Theo.