### PR TITLE
Middleware to diagnose browser calls in playwright

### DIFF
--- a/4_langchain_langgraph/community_contributions/drs_playwright_diagnostics/playwright_diagnostics_middleware.py
+++ b/4_langchain_langgraph/community_contributions/drs_playwright_diagnostics/playwright_diagnostics_middleware.py
@@ -1,0 +1,18 @@
+from langchain.agents.middleware import wrap_tool_call
+
+@wrap_tool_call
+async def diagnose_browser_calls(request, handler):
+    call = request.tool_call
+    print(f"  [tool] {call['name']}({call['args']})")
+
+    if call["name"] == "browser_evaluate":
+        probe = await request.tool.ainvoke({"function": "() => location.href"})
+        print(f"  [tool]   current page before evaluate: {getattr(probe, 'content', probe)}")
+
+    result = await handler(request)
+
+    status = getattr(result, "status", None)
+    content = getattr(result, "content", result)
+    if status == "error":
+        print(f"  [tool] {call['name']} FAILED: {content}")
+    return result


### PR DESCRIPTION
Add this middleware to an agent using the Playwright MCP tools.  The middleware will

1. Log all URLs passed to **browser_evaluate**
2. Log all errors